### PR TITLE
SCRUM-8: (Back+Front) Authentication Provider and Context

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,25 +1,28 @@
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { createBrowserRouter, RouterProvider } from "react-router-dom";
-import { useState } from "react";
-import Home from "@pages/Home";
-import Report from "@pages/Report";
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createBrowserRouter, RouterProvider } from 'react-router-dom';
+import { useState } from 'react';
+import Home from '@pages/Home';
+import Report from '@pages/Report';
+import AuthProvider from './providers/AuthProvider';
 
 const router = createBrowserRouter([
-  {
-    path: "/",
-    element: <Home />,
-  },
-  {
-    path: "/report",
-    element: <Report />,
-  },
+    {
+        path: '/',
+        element: <Home />,
+    },
+    {
+        path: '/report',
+        element: <Report />,
+    },
 ]);
 
 export default function App() {
-  const [queryClient] = useState(() => new QueryClient());
-  return (
-    <QueryClientProvider client={queryClient}>
-      <RouterProvider router={router} />
-    </QueryClientProvider>
-  );
+    const [queryClient] = useState(() => new QueryClient());
+    return (
+        <QueryClientProvider client={queryClient}>
+            <AuthProvider>
+                <RouterProvider router={router} />
+            </AuthProvider>
+        </QueryClientProvider>
+    );
 }

--- a/web/src/auth-client/SupabaseClient.ts
+++ b/web/src/auth-client/SupabaseClient.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl: string = import.meta.env.VITE_SUPABASE_URL as string;
+const supabaseKey: string = import.meta.env.VITE_SUPABASE_KEY as string;
+
+export const supabaseClient = createClient(supabaseUrl, supabaseKey);

--- a/web/src/contexts/AuthContext.ts
+++ b/web/src/contexts/AuthContext.ts
@@ -1,0 +1,12 @@
+import { User } from '@supabase/supabase-js';
+import { createContext } from 'react';
+
+interface IAuthContext {
+    user?: User | null;
+    signOut: () => void;
+}
+
+export const AuthContext = createContext<IAuthContext>({
+    user: null,
+    signOut: () => {},
+});

--- a/web/src/hooks/useAuth.ts
+++ b/web/src/hooks/useAuth.ts
@@ -1,0 +1,4 @@
+import { useContext } from 'react';
+import { AuthContext } from '../contexts/AuthContext';
+
+export const useAuth = () => useContext(AuthContext);

--- a/web/src/providers/AuthProvider.tsx
+++ b/web/src/providers/AuthProvider.tsx
@@ -1,0 +1,44 @@
+import { useState, useEffect, PropsWithChildren } from 'react';
+import { User } from '@supabase/supabase-js';
+import { supabaseClient } from '../auth-client/SupabaseClient';
+import { AuthContext } from '../contexts/AuthContext';
+
+interface ChildrenType extends PropsWithChildren {}
+
+export default function AuthProvider({ children }: ChildrenType) {
+    const [user, setUser] = useState<User>();
+
+    useEffect(() => {
+        const getUserData = async function () {
+            const {
+                data: { session },
+                error,
+            } = await supabaseClient.auth.getSession();
+            if (error) {
+                console.log(`Error: ${error}`);
+            }
+            setUser(session?.user);
+        };
+
+        const { data: listener } = supabaseClient.auth.onAuthStateChange(
+            function (_event, session) {
+                setUser(session?.user);
+            }
+        );
+
+        getUserData();
+
+        return () => {
+            listener?.subscription.unsubscribe();
+        };
+    }, []);
+
+    const value = {
+        user,
+        signOut: () => supabaseClient.auth.signOut(),
+    };
+
+    return (
+        <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
+    );
+}


### PR DESCRIPTION
## Context
This feature implements an Authentication Provider and Context using Supabase Authentication to manage authentication sessions and authentication state within the app.

Addresses [SCRUM-8](https://cpnz.atlassian.net/browse/SCRUM-8?atlOrigin=eyJpIjoiNjVlZThmZWVmYzQ1NGM3NWExOGFjMjFiYzgxM2Q5YTQiLCJwIjoiaiJ9) in Jira ticket.

## What Changed?

- Integrate and initalise Supabase client
- Implement an Authentication Provider to manage authentication session and listen to log out events to correctly manage log in state
- Add useAuth hook to access AuthContext which allows the authentication state to be passed across components in the app

## How To Review

1. AuthContext.ts in contexts folder
2. useAuth.ts hooks folder
3. AuthProvider.tsx in providers folder

## Testing
- Import useAuth hook and initialise a `user` variable.
- Tested it on the Report page by making it navigate to "/" if user is not signed in.
- Redirecting as expected. 
- Haven't been able to test the behaviour when signed in.

## Risks
Since I haven't been able to test the behaviour when signed in, it may need to be refactored in the future.
<!-- Where should the reviewer focus on (if any)? -->

## Notes
