### PR TITLE
Created CSS Classes for Texts & Updated Tailwind Config to include Brand colours

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,8 +1,8 @@
 @tailwind base;
-  @tailwind components;
-  @tailwind utilities;
+@tailwind components;
+@tailwind utilities;
 
-  @layer base {
+@layer base {
     :root {
       --background: 0 0% 100%;
       --foreground: 240 10% 3.9%;
@@ -75,18 +75,51 @@
     }
   }
 
+.text-xs {
+  @apply text-[14px] leading-[18px];
+}
+
+.text-sm {
+  @apply text-[18px] leading-[24px];
+}
+
 .text-body {
   @apply text-[24px] leading-[30px];
 }
 
+.text-lg {
+  @apply text-[28px] leading-[37px]
+}
+
 .text-subheading {
-  @apply text-[35px] leading-[45px] font-[600];
+  @apply text-[35px] leading-[48px] font-[600];
 }
 
 .text-heading {
-  @apply text-[48px] leading-[60px] font-[700];
+  @apply text-[48px] leading-[63px] font-[700];
 }
 
-.h1, h2, h3, h4 {
-
+.text-xs-light {
+  @apply text-[14px] leading-[18px] text-white;
 }
+
+.text-sm-light {
+  @apply text-[18px] leading-[24px] text-white;
+}
+
+.text-body-light {
+  @apply text-[24px] leading-[30px] text-white;
+}
+
+.text-lg-light {
+  @apply text-[28px] leading-[37px] text-white;
+}
+
+.text-subheading-light {
+  @apply text-[35px] leading-[48px] font-[600] text-white;
+}
+
+.text-heading-light {
+  @apply text-[48px] leading-[63px] font-[700] text-white;
+}
+

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -28,7 +28,9 @@ module.exports = {
       colors: {
         "cpnz-blue-400": "#6D93CD",
         "cpnz-blue-800": "#31358D",
-        "cpnz-grey-900": "221E1F",
+        "cpnz-blue-900": "#0f1363",
+        "cpnz-grey-300": "#D9D9D9",
+        "cpnz-grey-900": "#221E1F",
 
         border: "hsl(var(--border))",
         input: "hsl(var(--input))",


### PR DESCRIPTION
## Context

We're current repeatedly re-writing the same text styles. Containing these styles in classes will simplify the styling process as well as it easier for us to make changes to text styles in the future.

Closes

## What Changed?

- Added text style classes for sizes: "xs, sm, md, lg, subheading, heading", as well as light coloured versions of these.
- Updated tailwind-config to include brand colours 

## How To Review

- Check styling in web/src/index.css
- Check colours in web/tailwind.config.js

## Risks

Change existing styling of texts that currently using the following tailwind styles:
- .text-xs
- .text-sm
- .text-lg

