### PR TITLE
Add LogOn, LogOff, Amendment schemas, and some additional schemas to form relationships

### DIFF
--- a/api/prisma/migrations/20240506101017_log_on_off_amendment/migration.sql
+++ b/api/prisma/migrations/20240506101017_log_on_off_amendment/migration.sql
@@ -1,0 +1,137 @@
+/*
+  Warnings:
+
+  - The `role` column on the `Patrols` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+
+*/
+-- CreateEnum
+CREATE TYPE "Role" AS ENUM ('patrol', 'lead', 'admin');
+
+-- AlterTable
+ALTER TABLE "Patrols" DROP COLUMN "role",
+ADD COLUMN     "role" "Role" NOT NULL DEFAULT 'patrol';
+
+-- CreateTable
+CREATE TABLE "LogOn" (
+    "id" SERIAL NOT NULL,
+    "logOnAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expectedHours" INTEGER NOT NULL,
+    "policeStationBase" TEXT NOT NULL,
+    "cpCallSign" TEXT NOT NULL,
+    "logOnPatrolId" INTEGER NOT NULL,
+    "vehicleId" INTEGER NOT NULL,
+    "hasLiveryOrSignage" BOOLEAN NOT NULL,
+    "hasPoliceRadio" BOOLEAN NOT NULL,
+
+    CONSTRAINT "LogOn_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "OtherPatrolsInLogOn" (
+    "LogOnId" INTEGER NOT NULL,
+    "patrolId" INTEGER NOT NULL,
+
+    CONSTRAINT "OtherPatrolsInLogOn_pkey" PRIMARY KEY ("LogOnId","patrolId")
+);
+
+-- CreateTable
+CREATE TABLE "LogOff" (
+    "id" SERIAL NOT NULL,
+    "logOffAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "actualHours" INTEGER,
+    "policeStationBase" TEXT NOT NULL,
+    "cpCallSign" TEXT NOT NULL,
+    "logOffPatrolId" INTEGER NOT NULL,
+    "vehicleId" INTEGER NOT NULL,
+    "hasLiveryOrSignage" BOOLEAN NOT NULL,
+    "hasPoliceRadio" BOOLEAN NOT NULL,
+    "logOnId" INTEGER NOT NULL,
+
+    CONSTRAINT "LogOff_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "OtherPatrolsInLogOff" (
+    "LogOffId" INTEGER NOT NULL,
+    "patrolId" INTEGER NOT NULL,
+
+    CONSTRAINT "OtherPatrolsInLogOff_pkey" PRIMARY KEY ("LogOffId","patrolId")
+);
+
+-- CreateTable
+CREATE TABLE "Amendment" (
+    "id" SERIAL NOT NULL,
+    "logOffAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "shiftHoursChange" INTEGER,
+    "policeStationBase" TEXT,
+    "cpCallSign" TEXT,
+    "amendmentPatrolId" INTEGER NOT NULL,
+    "vehicleId" INTEGER NOT NULL,
+    "hasLiveryOrSignage" BOOLEAN NOT NULL,
+    "hasPoliceRadio" BOOLEAN NOT NULL,
+    "logOnId" INTEGER NOT NULL,
+
+    CONSTRAINT "Amendment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "OtherPatrolsInAmendment" (
+    "amendmentId" INTEGER NOT NULL,
+    "patrolId" INTEGER NOT NULL,
+
+    CONSTRAINT "OtherPatrolsInAmendment_pkey" PRIMARY KEY ("amendmentId","patrolId")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "LogOn_id_key" ON "LogOn"("id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "LogOff_id_key" ON "LogOff"("id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "LogOff_logOnId_key" ON "LogOff"("logOnId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Amendment_id_key" ON "Amendment"("id");
+
+-- AddForeignKey
+ALTER TABLE "LogOn" ADD CONSTRAINT "LogOn_logOnPatrolId_fkey" FOREIGN KEY ("logOnPatrolId") REFERENCES "Patrols"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "LogOn" ADD CONSTRAINT "LogOn_vehicleId_fkey" FOREIGN KEY ("vehicleId") REFERENCES "Vehicles"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "OtherPatrolsInLogOn" ADD CONSTRAINT "OtherPatrolsInLogOn_LogOnId_fkey" FOREIGN KEY ("LogOnId") REFERENCES "LogOn"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "OtherPatrolsInLogOn" ADD CONSTRAINT "OtherPatrolsInLogOn_patrolId_fkey" FOREIGN KEY ("patrolId") REFERENCES "Patrols"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "LogOff" ADD CONSTRAINT "LogOff_logOffPatrolId_fkey" FOREIGN KEY ("logOffPatrolId") REFERENCES "Patrols"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "LogOff" ADD CONSTRAINT "LogOff_vehicleId_fkey" FOREIGN KEY ("vehicleId") REFERENCES "Vehicles"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "LogOff" ADD CONSTRAINT "LogOff_logOnId_fkey" FOREIGN KEY ("logOnId") REFERENCES "LogOn"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "OtherPatrolsInLogOff" ADD CONSTRAINT "OtherPatrolsInLogOff_LogOffId_fkey" FOREIGN KEY ("LogOffId") REFERENCES "LogOff"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "OtherPatrolsInLogOff" ADD CONSTRAINT "OtherPatrolsInLogOff_patrolId_fkey" FOREIGN KEY ("patrolId") REFERENCES "Patrols"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Amendment" ADD CONSTRAINT "Amendment_amendmentPatrolId_fkey" FOREIGN KEY ("amendmentPatrolId") REFERENCES "Patrols"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Amendment" ADD CONSTRAINT "Amendment_vehicleId_fkey" FOREIGN KEY ("vehicleId") REFERENCES "Vehicles"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Amendment" ADD CONSTRAINT "Amendment_logOnId_fkey" FOREIGN KEY ("logOnId") REFERENCES "LogOn"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "OtherPatrolsInAmendment" ADD CONSTRAINT "OtherPatrolsInAmendment_amendmentId_fkey" FOREIGN KEY ("amendmentId") REFERENCES "Amendment"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "OtherPatrolsInAmendment" ADD CONSTRAINT "OtherPatrolsInAmendment_patrolId_fkey" FOREIGN KEY ("patrolId") REFERENCES "Patrols"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/api/prisma/migrations/20240506112523_fix_typo/migration.sql
+++ b/api/prisma/migrations/20240506112523_fix_typo/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `logOffAt` on the `Amendment` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "Amendment" DROP COLUMN "logOffAt",
+ADD COLUMN     "amendmentMadeAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;

--- a/api/prisma/migrations/20240507081453_fix_schemas/migration.sql
+++ b/api/prisma/migrations/20240507081453_fix_schemas/migration.sql
@@ -1,0 +1,104 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `logOnId` on the `Amendment` table. All the data in the column will be lost.
+  - You are about to drop the `LogOff` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `LogOn` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `OtherPatrolsInAmendment` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `OtherPatrolsInLogOff` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `OtherPatrolsInLogOn` table. If the table is not empty, all the data it contains will be lost.
+  - Added the required column `otherPatrolsName` to the `Amendment` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `shiftId` to the `Amendment` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- CreateEnum
+CREATE TYPE "logType" AS ENUM ('logOn', 'logOff');
+
+-- DropForeignKey
+ALTER TABLE "Amendment" DROP CONSTRAINT "Amendment_logOnId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "LogOff" DROP CONSTRAINT "LogOff_logOffPatrolId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "LogOff" DROP CONSTRAINT "LogOff_logOnId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "LogOff" DROP CONSTRAINT "LogOff_vehicleId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "LogOn" DROP CONSTRAINT "LogOn_logOnPatrolId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "LogOn" DROP CONSTRAINT "LogOn_vehicleId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "OtherPatrolsInAmendment" DROP CONSTRAINT "OtherPatrolsInAmendment_amendmentId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "OtherPatrolsInAmendment" DROP CONSTRAINT "OtherPatrolsInAmendment_patrolId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "OtherPatrolsInLogOff" DROP CONSTRAINT "OtherPatrolsInLogOff_LogOffId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "OtherPatrolsInLogOff" DROP CONSTRAINT "OtherPatrolsInLogOff_patrolId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "OtherPatrolsInLogOn" DROP CONSTRAINT "OtherPatrolsInLogOn_LogOnId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "OtherPatrolsInLogOn" DROP CONSTRAINT "OtherPatrolsInLogOn_patrolId_fkey";
+
+-- AlterTable
+ALTER TABLE "Amendment" DROP COLUMN "logOnId",
+ADD COLUMN     "otherPatrolsName" TEXT NOT NULL,
+ADD COLUMN     "shiftId" INTEGER NOT NULL,
+ADD COLUMN     "shiftType" "logType" NOT NULL DEFAULT 'logOn',
+ALTER COLUMN "hasLiveryOrSignage" DROP NOT NULL,
+ALTER COLUMN "hasPoliceRadio" DROP NOT NULL;
+
+-- DropTable
+DROP TABLE "LogOff";
+
+-- DropTable
+DROP TABLE "LogOn";
+
+-- DropTable
+DROP TABLE "OtherPatrolsInAmendment";
+
+-- DropTable
+DROP TABLE "OtherPatrolsInLogOff";
+
+-- DropTable
+DROP TABLE "OtherPatrolsInLogOn";
+
+-- CreateTable
+CREATE TABLE "Shifts" (
+    "id" SERIAL NOT NULL,
+    "type" "logType" NOT NULL,
+    "logOffAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expectedHours" DECIMAL(65,30),
+    "actualHours" DECIMAL(65,30),
+    "policeStationBase" TEXT NOT NULL,
+    "cpCallSign" TEXT NOT NULL,
+    "logPatrolId" INTEGER NOT NULL,
+    "otherPatrolsName" TEXT NOT NULL,
+    "vehicleId" INTEGER NOT NULL,
+    "hasLiveryOrSignage" BOOLEAN NOT NULL,
+    "hasPoliceRadio" BOOLEAN NOT NULL,
+
+    CONSTRAINT "Shifts_pkey" PRIMARY KEY ("id","type")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Shifts_id_key" ON "Shifts"("id");
+
+-- AddForeignKey
+ALTER TABLE "Shifts" ADD CONSTRAINT "Shifts_logPatrolId_fkey" FOREIGN KEY ("logPatrolId") REFERENCES "Patrols"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Shifts" ADD CONSTRAINT "Shifts_vehicleId_fkey" FOREIGN KEY ("vehicleId") REFERENCES "Vehicles"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Amendment" ADD CONSTRAINT "Amendment_shiftId_shiftType_fkey" FOREIGN KEY ("shiftId", "shiftType") REFERENCES "Shifts"("id", "type") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/api/prisma/migrations/20240507090401_fix_schemas/migration.sql
+++ b/api/prisma/migrations/20240507090401_fix_schemas/migration.sql
@@ -1,0 +1,19 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `logOffAt` on the `Shifts` table. All the data in the column will be lost.
+  - Added the required column `mobile` to the `Patrols` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropIndex
+DROP INDEX "Shifts_id_key";
+
+-- AlterTable
+ALTER TABLE "Amendment" ALTER COLUMN "otherPatrolsName" DROP NOT NULL;
+
+-- AlterTable
+ALTER TABLE "Patrols" ADD COLUMN     "mobile" TEXT NOT NULL;
+
+-- AlterTable
+ALTER TABLE "Shifts" DROP COLUMN "logOffAt",
+ADD COLUMN     "logAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;

--- a/api/prisma/migrations/20240507092707_change_field_type/migration.sql
+++ b/api/prisma/migrations/20240507092707_change_field_type/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Amendment" ALTER COLUMN "shiftHoursChange" SET DATA TYPE DECIMAL(65,30);

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -114,7 +114,7 @@ model OtherPatrolsInLogOff {
 
 model Amendment {
   id Int @id @unique @default(autoincrement())
-  logOffAt DateTime @default(now())
+  amendmentMadeAt DateTime @default(now())
   shiftHoursChange Int?
   policeStationBase String?
   cpCallSign String?

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -18,15 +18,12 @@ model Patrols{
   password String
   email String @unique
   name String
+  mobile String
   role Role @default(patrol)
-  vehicles Vehicles[]
-  reports Reports[]
-  logOns LogOn[]
-  asFollowerWhenLogOn OtherPatrolsInLogOn[]
-  logOffs LogOff[]
-  asFollowerWhenLogOff OtherPatrolsInLogOff[]
-  amendments Amendment[]
-  asFollowerInAmendment OtherPatrolsInAmendment[]
+  vehicles Vehicles[] @relation("belongToPatrol")
+  reports Reports[] @relation("writtenByPatrol")
+  shifts Shifts[] @relation("logByPatrol")
+  amendments Amendment[] @relation("submittedByPatrol")
   supervisorID Int? @unique
   supervisor Patrols? @relation("patrolSupervisor", fields: [supervisorID], references: [id])
   patrol Patrols? @relation("patrolSupervisor")
@@ -39,10 +36,9 @@ model Vehicles{
   make String
   model String
   patrolID Int
-  patrols Patrols @relation(fields: [patrolID], references: [id])
-  inLogOn LogOn[]
-  inLogOff LogOff[]
-  inAmendment Amendment[]
+  patrols Patrols @relation("belongToPatrol", fields: [patrolID], references: [id])
+  shifts Shifts[] @relation("isInShift")
+  inAmendment Amendment[] @relation("isInAmendment")
 }
 
 model Reports{
@@ -52,93 +48,60 @@ model Reports{
   location String
   patrolID Int
   reportIncidentType String
-  patrols Patrols @relation(fields: [patrolID], references: [id])
-  incident IncidentType @relation(fields: [reportIncidentType], references: [incidentType])
+  patrols Patrols @relation("writtenByPatrol", fields: [patrolID], references: [id])
+  incident IncidentType @relation("isIncidentOfType",fields: [reportIncidentType], references: [incidentType])
 }
 
 model IncidentType{
   incidentType String @id @unique
   description String
-  reports Reports[]
+  reports Reports[] @relation("isIncidentOfType")
 }
 
-model LogOn {
-  id Int @id @unique @default(autoincrement())
-  logOnAt DateTime @default(now())
-  expectedHours Int
+model Shifts {
+  id Int @default(autoincrement())
+  type logType 
+  logAt DateTime @default(now())
+  expectedHours Decimal?
+  actualHours Decimal?
   policeStationBase String
   cpCallSign String
-  logOnPatrolId Int
-  patrols Patrols @relation(fields: [logOnPatrolId], references: [id])
-  OtherPatrols OtherPatrolsInLogOn[]
+  logPatrolId Int
+  patrols Patrols @relation("logByPatrol", fields: [logPatrolId], references: [id])
+  otherPatrolsName String
   vehicleId Int
-  vehicles Vehicles @relation(fields: [vehicleId], references: [id])
+  vehicles Vehicles @relation("isInShift", fields: [vehicleId], references: [id])
   hasLiveryOrSignage Boolean
   hasPoliceRadio Boolean
-  logOff LogOff?
-  amendment Amendment[]
-}
-
-model OtherPatrolsInLogOn {
-  LogOnId Int
-  logOns LogOn @relation(fields: [LogOnId], references: [id])
-  patrolId Int
-  patrols Patrols @relation(fields: [patrolId], references: [id])
-  @@id([LogOnId, patrolId])
-}
-
-model LogOff {
-  id Int @id @unique @default(autoincrement())
-  logOffAt DateTime @default(now())
-  actualHours Int?
-  policeStationBase String
-  cpCallSign String
-  logOffPatrolId Int
-  patrols Patrols @relation(fields: [logOffPatrolId], references: [id])
-  OtherPatrols OtherPatrolsInLogOff[]
-  vehicleId Int
-  vehicles Vehicles @relation(fields: [vehicleId], references: [id])
-  hasLiveryOrSignage Boolean
-  hasPoliceRadio Boolean
-  logOnId Int @unique
-  logOn LogOn @relation(fields: [logOnId], references: [id])
-}
-
-model OtherPatrolsInLogOff {
-  LogOffId Int
-  logOffs LogOff @relation(fields: [LogOffId], references: [id])
-  patrolId Int
-  patrols Patrols @relation(fields: [patrolId], references: [id])
-  @@id([LogOffId, patrolId])
+  hasAmendment Amendment[] @relation("belongToShift")
+  @@id([id, type])
 }
 
 model Amendment {
   id Int @id @unique @default(autoincrement())
   amendmentMadeAt DateTime @default(now())
-  shiftHoursChange Int?
+  shiftHoursChange Decimal?
   policeStationBase String?
   cpCallSign String?
   amendmentPatrolId Int
-  patrols Patrols @relation(fields: [amendmentPatrolId], references: [id])
-  OtherPatrols OtherPatrolsInAmendment[]
+  patrols Patrols @relation("submittedByPatrol", fields: [amendmentPatrolId], references: [id])
+  otherPatrolsName String?
   vehicleId Int
-  vehicles Vehicles @relation(fields: [vehicleId], references: [id])
-  hasLiveryOrSignage Boolean
-  hasPoliceRadio Boolean
-  logOnId Int
-  logOn LogOn @relation(fields: [logOnId], references: [id])
-}
-
-model OtherPatrolsInAmendment {
-  amendmentId Int
-  amendment Amendment @relation(fields: [amendmentId], references: [id])
-  patrolId Int
-  patrols Patrols @relation(fields: [patrolId], references: [id])
-  @@id([amendmentId, patrolId])
+  vehicles Vehicles @relation("isInAmendment", fields: [vehicleId], references: [id])
+  hasLiveryOrSignage Boolean?
+  hasPoliceRadio Boolean?
+  shiftId Int
+  shiftType logType @default(logOn)
+  logOn Shifts @relation("belongToShift", fields: [shiftId, shiftType], references: [id, type])
 }
 
 enum Role {
   patrol
   lead
   admin
+}
+
+enum logType {
+  logOn
+  logOff
 }

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -21,6 +21,12 @@ model Patrols{
   role Role @default(patrol)
   vehicles Vehicles[]
   reports Reports[]
+  logOns LogOn[]
+  asFollowerWhenLogOn OtherPatrolsInLogOn[]
+  logOffs LogOff[]
+  asFollowerWhenLogOff OtherPatrolsInLogOff[]
+  amendments Amendment[]
+  asFollowerInAmendment OtherPatrolsInAmendment[]
   supervisorID Int? @unique
   supervisor Patrols? @relation("patrolSupervisor", fields: [supervisorID], references: [id])
   patrol Patrols? @relation("patrolSupervisor")
@@ -34,6 +40,9 @@ model Vehicles{
   model String
   patrolID Int
   patrols Patrols @relation(fields: [patrolID], references: [id])
+  inLogOn LogOn[]
+  inLogOff LogOff[]
+  inAmendment Amendment[]
 }
 
 model Reports{
@@ -51,6 +60,81 @@ model IncidentType{
   incidentType String @id @unique
   description String
   reports Reports[]
+}
+
+model LogOn {
+  id Int @id @unique @default(autoincrement())
+  logOnAt DateTime @default(now())
+  expectedHours Int
+  policeStationBase String
+  cpCallSign String
+  logOnPatrolId Int
+  patrols Patrols @relation(fields: [logOnPatrolId], references: [id])
+  OtherPatrols OtherPatrolsInLogOn[]
+  vehicleId Int
+  vehicles Vehicles @relation(fields: [vehicleId], references: [id])
+  hasLiveryOrSignage Boolean
+  hasPoliceRadio Boolean
+  logOff LogOff?
+  amendment Amendment[]
+}
+
+model OtherPatrolsInLogOn {
+  LogOnId Int
+  logOns LogOn @relation(fields: [LogOnId], references: [id])
+  patrolId Int
+  patrols Patrols @relation(fields: [patrolId], references: [id])
+  @@id([LogOnId, patrolId])
+}
+
+model LogOff {
+  id Int @id @unique @default(autoincrement())
+  logOffAt DateTime @default(now())
+  actualHours Int?
+  policeStationBase String
+  cpCallSign String
+  logOffPatrolId Int
+  patrols Patrols @relation(fields: [logOffPatrolId], references: [id])
+  OtherPatrols OtherPatrolsInLogOff[]
+  vehicleId Int
+  vehicles Vehicles @relation(fields: [vehicleId], references: [id])
+  hasLiveryOrSignage Boolean
+  hasPoliceRadio Boolean
+  logOnId Int @unique
+  logOn LogOn @relation(fields: [logOnId], references: [id])
+}
+
+model OtherPatrolsInLogOff {
+  LogOffId Int
+  logOffs LogOff @relation(fields: [LogOffId], references: [id])
+  patrolId Int
+  patrols Patrols @relation(fields: [patrolId], references: [id])
+  @@id([LogOffId, patrolId])
+}
+
+model Amendment {
+  id Int @id @unique @default(autoincrement())
+  logOffAt DateTime @default(now())
+  shiftHoursChange Int?
+  policeStationBase String?
+  cpCallSign String?
+  amendmentPatrolId Int
+  patrols Patrols @relation(fields: [amendmentPatrolId], references: [id])
+  OtherPatrols OtherPatrolsInAmendment[]
+  vehicleId Int
+  vehicles Vehicles @relation(fields: [vehicleId], references: [id])
+  hasLiveryOrSignage Boolean
+  hasPoliceRadio Boolean
+  logOnId Int
+  logOn LogOn @relation(fields: [logOnId], references: [id])
+}
+
+model OtherPatrolsInAmendment {
+  amendmentId Int
+  amendment Amendment @relation(fields: [amendmentId], references: [id])
+  patrolId Int
+  patrols Patrols @relation(fields: [patrolId], references: [id])
+  @@id([amendmentId, patrolId])
 }
 
 enum Role {

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -18,7 +18,7 @@ model Patrols{
   password String
   email String @unique
   name String
-  role String @default("Patrol")
+  role Role @default(patrol)
   vehicles Vehicles[]
   reports Reports[]
   supervisorID Int? @unique
@@ -51,4 +51,10 @@ model IncidentType{
   incidentType String @id @unique
   description String
   reports Reports[]
+}
+
+enum Role {
+  patrol
+  lead
+  admin
 }


### PR DESCRIPTION
## Context

<!-- Include contextual info that can't be found in the linked issue. Why are you making this change? -->

To have all info record for all emails sent by patrols, we created two additional schemas and two more enum schemas

## What Changed?

<!-- What changes did you make? -->
- Add `Shift` schema, it has ID and Type as primary keys, it has one-many relationship with the patrol who logon or logoff, and other required fields.
- add `Amendment` schema, same fields and relationships as `Shift` has, with foreign key references to `Shift`
- Fix `Patrol` to have only three roles


## How To Review

<!-- What (rough) order should the reviewer view your files? -->
review [schema.prisma](https://github.com/UoaWDCC/patrols/blob/cpnz/tony/api/prisma/schema.prisma)

## Testing

<!-- What testing did you do, if any? -->
N/A

## Risks
N/A

<!-- Where should the reviewer focus on (if any)? -->

## Notes
N/A
