### PR TITLE
Feat/post email

### DIFF
--- a/web/src/pages/Login.tsx
+++ b/web/src/pages/Login.tsx
@@ -17,11 +17,7 @@ import axios from "axios";
 import { z } from "zod";
 import { useForm } from "react-hook-form";
 import { useAuth } from "../hooks/useAuth";
-
-const tokenSchema = z.object({
-  access_token: z.string(),
-  refresh_token: z.string(),
-});
+import { tokenSchema } from "../schemas";
 
 export default function Login() {
   const formSchema = z.object({

--- a/web/src/pages/Logon.tsx
+++ b/web/src/pages/Logon.tsx
@@ -57,7 +57,7 @@ export default function Logon() {
     try {
       const email = await axios.post(
         `${import.meta.env.VITE_API_URL}/send-email`,
-        { email: user?.email, patrolName: data.patrol1Name, patrolID: "10", formData: JSON.stringify(data)}
+        { email: "jasonabc0626@gmail.com", patrolName: data.patrol1Name, patrolID: "10", formData: JSON.stringify(data)}
       );
 
       // Navigates to Loghome if succesfully logged on. 

--- a/web/src/pages/Logon.tsx
+++ b/web/src/pages/Logon.tsx
@@ -14,9 +14,13 @@ import {
 } from "@components/ui/form";
 import userIcon from "../assets/images/gorilla.png";
 import { FaCog } from "react-icons/fa";
+import axios from "axios";
+import { useAuth } from "../hooks/useAuth";
 
 export default function Logon() {
   const navigate = useNavigate();
+
+  const { user } = useAuth();
 
   const formSchema = z.object({
     shiftTime: z.string(),
@@ -49,9 +53,20 @@ export default function Logon() {
     },
   });
 
-  const onSubmit = (data: z.infer<typeof formSchema>) => {
-    console.log(data);
-    navigate("/LogHome");
+  const onSubmit = async (data: z.infer<typeof formSchema>) => {
+    try {
+      const email = await axios.post(
+        `${import.meta.env.VITE_API_URL}/send-email`,
+        { email: user?.email, patrolName: data.patrol1Name, patrolID: "10", formData: JSON.stringify(data)}
+      );
+
+      // Navigates to Loghome if succesfully logged on. 
+      navigate("/LogHome");
+    } catch (error) {
+      axios.isAxiosError(error)
+        ? console.log(error.response?.data.error)
+        : console.error("Unexpected error during login:", error);
+    }
   };
 
   return (

--- a/web/src/schemas/index.ts
+++ b/web/src/schemas/index.ts
@@ -6,3 +6,15 @@ export const userDetailsSchema = z.object({
   email: z.string().email(),
   vehicles: z.array(z.string()),
 });
+
+export const tokenSchema = z.object({
+  access_token: z.string(),
+  refresh_token: z.string(),
+});
+
+export const emailSchema = z.object({
+  email: z.string(),
+  patrolName: z.string(),
+  patrolID: z.string(),
+  formData: z.string(),
+})

--- a/web/src/schemas/index.ts
+++ b/web/src/schemas/index.ts
@@ -13,8 +13,8 @@ export const tokenSchema = z.object({
 });
 
 export const emailSchema = z.object({
-  email: z.string(),
   patrolName: z.string(),
+  email: z.string(),
   patrolID: z.string(),
   formData: z.string(),
 })


### PR DESCRIPTION
## Context

The logon form should send an email to the ECC after being submitted. 

## What Changed?

- Linked the logon form to the send email API endpoint
- Can now send emails using hard coded email and patrol ID
- Moved the tokenSchema into the Schema folder
- Created a new zod schema for emails. 

## How To Review

- /web/src/pages/login.tsx
- /web/src/pages/logon.tsx
- /web/src/schema/index.ts

## Testing

Tested by submitting the logon form after filling out on the data, correctly sends email to the hard coded email address with the email body being a stringified JSON object with all the form fields information. 

## Risks

- Emails are sent from Resend's testing email, and can only send emails to registered account with resend. 

## Notes
