### PR TITLE
Hotfix/get all report for lead db query fix

### DIFF
--- a/api/controller/reportController.ts
+++ b/api/controller/reportController.ts
@@ -1,5 +1,5 @@
 import type { Request, Response } from 'express';
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient, Role } from '@prisma/client';
 
 const prisma = new PrismaClient();
 
@@ -52,7 +52,6 @@ export const updateReport = async (req: Request, res: Response) => {
     }
 }
 
-
 export const deleteReport = async (req: Request, res: Response) => {
     try {
     const { id } = req.params;
@@ -78,20 +77,15 @@ export const getAllReportForLead = async (req: Request, res: Response) => {
             {where: {id: Number(patrolLeadId)},
             select: {
                 id: true,
-
-                //Issue with fetch role, expects a String but patrol(role) is Enum in our schema
-                // role: true
+                role: true
             }        
         });
     
         if (!patrolLead) { // Check if patrol exists
             return res.status(404).json({error: 'No such patrol lead'})
-        } 
-
-        // Need to implement role check once type compatibility issue is fixed. 
-        // else if (patrolLead.role !== 'lead') { // Check if patrol is a lead
-        //     return res.status(401).json({error: 'You are not authorized to view this report'})
-        // }
+        } else if (patrolLead.role !== Role.lead) { // Check if patrol is a lead
+            return res.status(401).json({error: 'You are not authorized to view this report'})
+        }
 
         // Get all the patrols assigned to the patrol lead
         const assignedPatrol = await prisma.patrols.findUnique({where: {supervisorID: Number(patrolLeadId)}, select:{id: true, reports: true}});

--- a/api/controller/reportController.ts
+++ b/api/controller/reportController.ts
@@ -82,7 +82,7 @@ export const getAllReportForLead = async (req: Request, res: Response) => {
         });
     
         if (!patrolLead) { // Check if patrol exists
-            return res.status(404).json({error: 'No such patrol lead'})
+            return res.status(404).json({error: 'Patrol does not exist'})
         } else if (patrolLead.role !== Role.lead) { // Check if patrol is a lead
             return res.status(401).json({error: 'You are not authorized to view this report'})
         }


### PR DESCRIPTION
## Context

In getAllReportForLead function in reportController.ts, line 76, when you retrieve the patrols role using the query, it throws an error because the role data fetched from schema is an enum, however the program expects a string.

Closes

## What Changed?

Import the Role enum from the prisma schema using the client (line 2)

## How To Review

<!-- What (rough) order should the reviewer view your files? -->

## Testing

Tested the getAllReportForLead api for patrol lead with a id of 12. Should give me all the reports of assigned patrols.

![image](https://github.com/UoaWDCC/patrols/assets/126467027/0076a1f5-421c-449c-934f-3e33c4367bae)

Test with patrol that is not a lead with id of 1. Should give me an error message saying "You are not authorized to view this report"

![image](https://github.com/UoaWDCC/patrols/assets/126467027/98c69b2b-5ad2-4466-8851-47411614cd4d)

## Risks

<!-- Where should the reviewer focus on (if any)? -->

## Notes

If the schema is changed, or schema is never generated, the prisma scheme needs to be generated using such command: 
In  api\prisma use: 

npx prisma generate
