### PR TITLE
refactor: Remove unused tables

### DIFF
--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -1,6 +1,6 @@
 generator client {
   provider = "prisma-client-js"
-  output = "../node_modules/.prisma/client"
+  output   = "../node_modules/.prisma/client"
 }
 
 datasource db {
@@ -89,33 +89,6 @@ model Amendment {
   patrols            Patrols  @relation("submittedByPatrol", fields: [amendmentPatrolId], references: [id])
   logOn              Shifts   @relation("belongToShift", fields: [shiftId, shiftType], references: [id, type])
   vehicles           Vehicles @relation("isInAmendment", fields: [vehicleId], references: [id])
-}
-
-model amendments_dev {
-  id          BigInt    @id
-  created_at  DateTime? @db.Timestamptz(6)
-  updated_at  DateTime? @db.Timestamptz(6)
-  content     String
-  subject     String
-  member_id   BigInt
-  user_id     BigInt
-  patrol_id   BigInt
-  district_id BigInt
-  status      String
-}
-
-/// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
-model amendments_prod {
-  id          BigInt    @id(map: "amendments_pkey")
-  created_at  DateTime? @db.Timestamptz(6)
-  updated_at  DateTime? @db.Timestamptz(6)
-  content     String
-  subject     String
-  member_id   BigInt
-  user_id     BigInt
-  patrol_id   BigInt
-  district_id BigInt
-  status      String
 }
 
 model district_stats_dev {
@@ -262,48 +235,6 @@ model imports_prod {
   district           String
 }
 
-model logs_dev {
-  id          BigInt    @id
-  created_at  DateTime? @db.Timestamptz(6)
-  updated_at  DateTime? @db.Timestamptz(6)
-  user_id     BigInt
-  user_email  String
-  description String
-  member_id   BigInt
-}
-
-/// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
-model logs_prod {
-  id          BigInt    @id(map: "logs_pkey")
-  created_at  DateTime? @db.Timestamptz(6)
-  updated_at  DateTime? @db.Timestamptz(6)
-  user_id     BigInt
-  user_email  String
-  description String
-  member_id   BigInt
-}
-
-model member_documents_dev {
-  id            BigInt       @id
-  created_at    DateTime?    @db.Timestamptz(6)
-  updated_at    DateTime?    @db.Timestamptz(6)
-  member_id     BigInt
-  original_name String
-  unique_id     String       @unique
-  members_prod  members_prod @relation(fields: [member_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
-}
-
-/// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
-model member_documents_prod {
-  id            BigInt       @id(map: "member_documents_pkey")
-  created_at    DateTime?    @db.Timestamptz(6)
-  updated_at    DateTime?    @db.Timestamptz(6)
-  member_id     BigInt
-  original_name String
-  unique_id     String       @unique(map: "member_documents_unique_id_key")
-  members_prod  members_prod @relation(fields: [member_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "member_documents_member_id_fkey")
-}
-
 /// This model or at least one of its fields has comments in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-comments
 model members_dev {
   id                               BigInt       @id
@@ -363,10 +294,10 @@ model members_dev {
 
 /// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
 model members_prod {
-  id                               BigInt                  @id(map: "members_pkey")
-  created_at                       DateTime?               @db.Timestamptz(6)
-  updated_at                       DateTime?               @db.Timestamptz(6)
-  active_member                    Int                     @db.SmallInt
+  id                               BigInt       @id(map: "members_pkey")
+  created_at                       DateTime?    @db.Timestamptz(6)
+  updated_at                       DateTime?    @db.Timestamptz(6)
+  active_member                    Int          @db.SmallInt
   patrol_id                        BigInt
   district_id                      BigInt
   cpnz_id                          BigInt
@@ -386,149 +317,36 @@ model members_prod {
   city                             String
   post_code                        String
   email                            String?
-  patroller                        Int                     @db.SmallInt
-  officer                          Int                     @db.SmallInt
+  patroller                        Int          @db.SmallInt
+  officer                          Int          @db.SmallInt
   officer_type                     String
   languages                        String?
   skills                           String?
   notes                            String?
   photo_id                         String
-  constabulary                     Int                     @default(1) @db.SmallInt
+  constabulary                     Int          @default(1) @db.SmallInt
   qi                               String?
-  status                           String                  @default("active")
-  officer_patroller                Int?                    @db.SmallInt
-  officer_patrol_leader_1          Int?                    @db.SmallInt
-  officer_patrol_leader_2          Int?                    @db.SmallInt
-  officer_secretary                Int?                    @db.SmallInt
-  officer_patrol_trainer           Int?                    @db.SmallInt
-  officer_avp1                     Int?                    @db.SmallInt
-  officer_avp2                     Int?                    @db.SmallInt
-  officer_health_and_safety        Int?                    @db.SmallInt
-  officer_patrol_member_other      Int?                    @db.SmallInt
-  officer_district_leader          Int?                    @db.SmallInt
-  officer_district_trainer         Int?                    @db.SmallInt
-  officer_district_support_officer Int?                    @db.SmallInt
-  officer_district_other           Int?                    @db.SmallInt
-  officer_cpnz_staff               Int?                    @db.SmallInt
-  officer_probationer              Int?                    @db.SmallInt
-  access_website                   Int?                    @db.SmallInt
-  trained                          Int                     @default(0) @db.SmallInt
-  new_nationality                  String                  @default("Not known")
-  treasurer                        Int?                    @db.SmallInt
-  member_documents_dev             member_documents_dev[]
-  member_documents_prod            member_documents_prod[]
-  patrols_prod                     patrols_prod            @relation(fields: [patrol_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "members_patrol_id_fkey")
-}
-
-/// The underlying table does not contain a valid unique identifier and can therefore currently not be handled by Prisma Client.
-model migrations_dev {
-  migration String
-  batch     BigInt
-
-  @@ignore
-}
-
-/// The underlying table does not contain a valid unique identifier and can therefore currently not be handled by Prisma Client.
-/// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
-model migrations_prod {
-  migration String
-  batch     BigInt
-
-  @@ignore
-}
-
-model old_stats_migration_changes_dev {
-  id                BigInt    @id
-  created_at        DateTime? @db.Timestamp(6)
-  updated_at        DateTime? @db.Timestamp(6)
-  stats_patrol_name String
-  stats_callsign    String
-  district          BigInt
-  founded           BigInt
-  active            String
-  no_name_change    String
-  new_name          String
-}
-
-/// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
-model old_stats_migration_changes_prod {
-  id                BigInt    @id(map: "old_stats_migration_changes_pkey")
-  created_at        DateTime? @db.Timestamp(6)
-  updated_at        DateTime? @db.Timestamp(6)
-  stats_patrol_name String
-  stats_callsign    String
-  district          BigInt
-  founded           BigInt
-  active            String
-  no_name_change    String
-  new_name          String
-}
-
-model old_stats_patrol_reference_dev {
-  id              BigInt    @id
-  created_at      DateTime? @db.Timestamp(6)
-  updated_at      DateTime? @db.Timestamp(6)
-  old_stats_index BigInt
-  current_index   BigInt
-}
-
-/// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
-model old_stats_patrol_reference_prod {
-  id              BigInt    @id(map: "old_stats_patrol_reference_pkey")
-  created_at      DateTime? @db.Timestamp(6)
-  updated_at      DateTime? @db.Timestamp(6)
-  old_stats_index BigInt
-  current_index   BigInt
-}
-
-model options_dev {
-  id                    BigInt    @id(map: "options_prod_dev_pkey")
-  created_at            DateTime? @db.Timestamp(6)
-  updated_at            DateTime? @db.Timestamp(6)
-  last_issued_patrol_id BigInt
-}
-
-/// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
-model options_prod {
-  id                    BigInt    @id(map: "options_pkey")
-  created_at            DateTime? @db.Timestamp(6)
-  updated_at            DateTime? @db.Timestamp(6)
-  last_issued_patrol_id BigInt
-}
-
-/// This model or at least one of its fields has comments in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-comments
-model password_resets_dev {
-  email      String
-  token      String    @id
-  created_at DateTime? @default(now()) @db.Timestamptz(6)
-}
-
-/// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
-model password_resets_prod {
-  email      String
-  token      String    @id(map: "password_resets_pkey")
-  created_at DateTime? @default(now()) @db.Timestamptz(6)
-}
-
-model patrol_documents_dev {
-  id            BigInt       @id
-  created_at    DateTime?    @db.Timestamptz(6)
-  updated_at    DateTime?    @db.Timestamptz(6)
-  patrol_id     BigInt
-  original_name String
-  unique_id     String       @unique
-  patrols_prod  patrols_prod @relation(fields: [patrol_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
-}
-
-/// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
-model patrol_documents_prod {
-  id            BigInt       @id(map: "patrol_documents_pkey")
-  created_at    DateTime?    @db.Timestamptz(6)
-  updated_at    DateTime?    @db.Timestamptz(6)
-  patrol_id     BigInt
-  original_name String
-  unique_id     String       @unique(map: "patrol_documents_unique_id_key")
-  patrols_prod  patrols_prod @relation(fields: [patrol_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "patrol_documents_patrol_id_fkey")
+  status                           String       @default("active")
+  officer_patroller                Int?         @db.SmallInt
+  officer_patrol_leader_1          Int?         @db.SmallInt
+  officer_patrol_leader_2          Int?         @db.SmallInt
+  officer_secretary                Int?         @db.SmallInt
+  officer_patrol_trainer           Int?         @db.SmallInt
+  officer_avp1                     Int?         @db.SmallInt
+  officer_avp2                     Int?         @db.SmallInt
+  officer_health_and_safety        Int?         @db.SmallInt
+  officer_patrol_member_other      Int?         @db.SmallInt
+  officer_district_leader          Int?         @db.SmallInt
+  officer_district_trainer         Int?         @db.SmallInt
+  officer_district_support_officer Int?         @db.SmallInt
+  officer_district_other           Int?         @db.SmallInt
+  officer_cpnz_staff               Int?         @db.SmallInt
+  officer_probationer              Int?         @db.SmallInt
+  access_website                   Int?         @db.SmallInt
+  trained                          Int          @default(0) @db.SmallInt
+  new_nationality                  String       @default("Not known")
+  treasurer                        Int?         @db.SmallInt
+  patrols_prod                     patrols_prod @relation(fields: [patrol_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "members_patrol_id_fkey")
 }
 
 model patrols_dev {
@@ -547,52 +365,19 @@ model patrols_dev {
 
 /// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
 model patrols_prod {
-  id                    BigInt                  @id(map: "patrols_pkey")
-  created_at            DateTime?               @db.Timestamptz(6)
-  updated_at            DateTime?               @db.Timestamptz(6)
-  name                  String
-  active                Int                     @db.SmallInt
-  district_id           BigInt
-  notes                 String?
-  call_sign             String?
-  year_joined           String?
-  email                 String                  @default("office@cpnz.org.nz")
-  members_dev           members_dev[]
-  members_prod          members_prod[]
-  patrol_documents_dev  patrol_documents_dev[]
-  patrol_documents_prod patrol_documents_prod[]
-  districts_prod        districts_prod          @relation(fields: [district_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "patrols_district_id_fkey")
-  police_liaisons_dev   police_liaisons_dev[]
-  police_liaisons_prod  police_liaisons_prod[]
-}
-
-model police_liaisons_dev {
-  id           BigInt       @id
-  created_at   DateTime?    @db.Timestamptz(6)
-  updated_at   DateTime?    @db.Timestamptz(6)
-  name         String
-  patrol_id    BigInt
-  email        String
-  phone        String
-  qi           String?
-  rank         String?
-  station      String?
-  patrols_prod patrols_prod @relation(fields: [patrol_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
-}
-
-/// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
-model police_liaisons_prod {
-  id           BigInt       @id(map: "police_liaisons_pkey")
-  created_at   DateTime?    @db.Timestamptz(6)
-  updated_at   DateTime?    @db.Timestamptz(6)
-  name         String
-  patrol_id    BigInt
-  email        String
-  phone        String
-  qi           String?
-  rank         String?
-  station      String?
-  patrols_prod patrols_prod @relation(fields: [patrol_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "police_liaisons_patrol_id_fkey")
+  id             BigInt         @id(map: "patrols_pkey")
+  created_at     DateTime?      @db.Timestamptz(6)
+  updated_at     DateTime?      @db.Timestamptz(6)
+  name           String
+  active         Int            @db.SmallInt
+  district_id    BigInt
+  notes          String?
+  call_sign      String?
+  year_joined    String?
+  email          String         @default("office@cpnz.org.nz")
+  members_dev    members_dev[]
+  members_prod   members_prod[]
+  districts_prod districts_prod @relation(fields: [district_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "patrols_district_id_fkey")
 }
 
 model stats_dev {
@@ -614,25 +399,6 @@ model stats_dev {
   training          Float?
   administration    Float?
   submitter_cpnz_id BigInt
-}
-
-model stats_documents_dev {
-  id             BigInt?
-  created_at     DateTime? @db.Timestamptz(6)
-  updated_at     DateTime? @db.Timestamptz(6)
-  document_label String
-  original_name  String
-  unique_id      String    @unique
-}
-
-/// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
-model stats_documents_prod {
-  id             BigInt    @id
-  created_at     DateTime? @db.Timestamptz(6)
-  updated_at     DateTime? @db.Timestamptz(6)
-  document_label String
-  original_name  String
-  unique_id      String    @unique(map: "stats_documents_unique_id_key")
 }
 
 /// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
@@ -659,8 +425,8 @@ model stats_prod {
 
 model user_export_dev {
   id         BigInt    @id
-  created_at DateTime? @db.Timestamptz(6)
-  updated_at DateTime? @db.Timestamptz(6)
+  created_at DateTime? @default(now()) @db.Timestamptz(6)
+  updated_at DateTime? @default(now()) @db.Timestamptz(6)
   username   String
   password   String
   email      String
@@ -671,8 +437,8 @@ model user_export_dev {
 /// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
 model user_export_prod {
   id         BigInt    @id(map: "user_export_pkey")
-  created_at DateTime? @db.Timestamptz(6)
-  updated_at DateTime? @db.Timestamptz(6)
+  created_at DateTime? @default(now()) @db.Timestamptz(6)
+  updated_at DateTime? @default(now()) @db.Timestamptz(6)
   username   String
   password   String
   email      String


### PR DESCRIPTION
## Context

Too many redundant tables that are not necessary for operations in web app

Closes

## What Changed?

Removed the following tables:
- amendments  
- logs
- member_documents
- migrations
- old_stats_migration_changes
- old_stats_patrol_reference
- patrol_documents
- password_resets
- police_liasons
- options
- stats_documents

## How To Review

api/prisma/schema.prisma