### PR TITLE
Feat/cache user data

### DIFF
--- a/web/src/components/profile/VehicleDetailsForm.tsx
+++ b/web/src/components/profile/VehicleDetailsForm.tsx
@@ -15,8 +15,13 @@ export default function VehicleDetailsForm() {
   const vehicleSelectRef = useRef<HTMLSelectElement | null>(null);
   const [canSaveVehicle, setCanSaveVehicle] = useState(false);
 
-  const { currentUserVehicles, selectedVehicle, setSelectedVehicle, loading } =
-    useUserData();
+  const {
+    currentUserVehicles,
+    selectedVehicle,
+    setSelectedVehicle,
+    loading,
+    refetch,
+  } = useUserData();
 
   const changeSelectedVehicle = async () => {
     try {
@@ -29,6 +34,7 @@ export default function VehicleDetailsForm() {
         `${import.meta.env.VITE_API_URL}/user/updateUserSelectedVehicle`,
         updateSelectedVehicle
       );
+      refetch();
     } catch (error) {
       console.log(error);
     }

--- a/web/src/hooks/useUserData.ts
+++ b/web/src/hooks/useUserData.ts
@@ -1,21 +1,44 @@
-import axios from "axios";
-import { useEffect, useState } from "react";
-import { z } from "zod";
-import { userDetailsSchema, vehicleDetailsSchema } from "../schemas";
+import axios from 'axios';
+import { useEffect, useState } from 'react';
+import { z } from 'zod';
+import { useQuery } from '@tanstack/react-query';
+import {
+  userDetailsSchema,
+  patrolDetailsSchema,
+  vehicleDetailsSchema,
+} from '../schemas';
 
 type UserDetails = z.infer<typeof userDetailsSchema>;
 type VehicleDetails = z.infer<typeof vehicleDetailsSchema>;
 
+const fetchUserData = async () => {
+  try {
+    const response = await axios.get(
+      `${import.meta.env.VITE_API_URL}/user/getUserDetails`
+    );
+    const { userDetails, patrolDetails, vehicleDetails } = response.data;
+    const parsedUserDetails = userDetailsSchema.parse(userDetails);
+    const parsedPatrolDetails = patrolDetailsSchema.parse(patrolDetails);
+    const parsedVehicleDetails = vehicleDetailsSchema
+      .array()
+      .parse(vehicleDetails);
+    console.log('API CALLED');
+    return { parsedUserDetails, parsedPatrolDetails, parsedVehicleDetails };
+  } catch (error) {
+    console.log('Error: ', error);
+  }
+};
+
 const useUserData = () => {
   const [loading, setLoading] = useState(true);
   const [currentUserDetails, setCurrentUserDetails] = useState<UserDetails>();
-  const [fullName, setFullName] = useState<string>("");
-  const [cpnzID, setCPNZID] = useState<string>("");
-  const [email, setEmail] = useState<string>("");
-  const [mobileNumber, setMobileNumber] = useState<string>("");
-  const [callSign, setCallSign] = useState<string>("");
-  const [patrolName, setPatrolName] = useState<string>("");
-  const [policeStation, setPoliceStation] = useState<string>("");
+  const [fullName, setFullName] = useState<string>('');
+  const [cpnzID, setCPNZID] = useState<string>('');
+  const [email, setEmail] = useState<string>('');
+  const [mobileNumber, setMobileNumber] = useState<string>('');
+  const [callSign, setCallSign] = useState<string>('');
+  const [patrolName, setPatrolName] = useState<string>('');
+  const [policeStation, setPoliceStation] = useState<string>('');
   const [currentUserVehicles, setCurrentUserVehicles] = useState<
     VehicleDetails[]
   >([]);
@@ -24,49 +47,45 @@ const useUserData = () => {
   );
   const [membersInPatrol, setMembersInPatrol] = useState<UserDetails[]>([]);
 
+  const { data } = useQuery({
+    queryKey: ['userData'],
+    queryFn: fetchUserData,
+    staleTime: 300000,
+  });
+
   useEffect(() => {
-    const fetchUserData = async () => {
-      try {
-        const response = await axios.get(
-          `${import.meta.env.VITE_API_URL}/user/getUserDetails`
+    if (data) {
+      const { parsedUserDetails, parsedPatrolDetails, parsedVehicleDetails } =
+        data;
+
+      setCurrentUserDetails(parsedUserDetails);
+      setCallSign(parsedUserDetails.call_sign);
+      setPatrolName(parsedPatrolDetails.name);
+      setPoliceStation(parsedUserDetails.police_station.replace(/_/g, ' '));
+      setEmail(parsedUserDetails.email);
+      setCPNZID(parsedUserDetails.cpnz_id);
+      setMobileNumber(parsedUserDetails.mobile_phone);
+      setFullName(
+        `${parsedUserDetails.first_names} ${parsedUserDetails.surname}`
+      );
+
+      if (parsedVehicleDetails.length === 0) {
+        setSelectedVehicle(null);
+        setCurrentUserVehicles([]);
+      } else {
+        setSelectedVehicle(
+          parsedVehicleDetails.find((vehicle) => vehicle.selected) || null
         );
-
-        const { userDetails, patrolDetails, vehicleDetails } = response.data;
-        const parsedUserDetails = userDetailsSchema.parse(userDetails);
-        const parsedVehicleDetails = vehicleDetailsSchema
-          .array()
-          .parse(vehicleDetails);
-        setCurrentUserDetails(parsedUserDetails);
-        setCallSign(userDetails.call_sign);
-        setPatrolName(patrolDetails.name);
-        setPoliceStation(userDetails.police_station.replace(/_/g, " ")); // Replace enum underscores with space
-        setEmail(userDetails.email);
-        setCPNZID(userDetails.cpnz_id);
-        setMobileNumber(userDetails.mobile_phone);
-        setFullName(`${userDetails.first_names} ${userDetails.surname}`);
-
-        if (parsedVehicleDetails.length === 0) {
-          setSelectedVehicle(null);
-          setCurrentUserVehicles([]);
-        } else {
-          setSelectedVehicle(
-            parsedVehicleDetails.find((vehicle) => vehicle.selected) || null
-          );
-          const reorderedVehicles = [
-            ...parsedVehicleDetails.filter((vehicle) => vehicle.selected),
-            ...parsedVehicleDetails.filter((vehicle) => !vehicle.selected),
-          ];
-          setCurrentUserVehicles(reorderedVehicles);
-        }
-        setMembersInPatrol(patrolDetails.members_dev);
-        setLoading(false);
-      } catch (e) {
-        console.log("Error: ", e);
+        const reorderedVehicles = [
+          ...parsedVehicleDetails.filter((vehicle) => vehicle.selected),
+          ...parsedVehicleDetails.filter((vehicle) => !vehicle.selected),
+        ];
+        setCurrentUserVehicles(reorderedVehicles);
       }
-    };
-
-    fetchUserData();
-  }, []);
+      setMembersInPatrol(parsedPatrolDetails.members_dev);
+      setLoading(false);
+    }
+  }, [data]);
 
   return {
     loading,

--- a/web/src/hooks/useUserData.ts
+++ b/web/src/hooks/useUserData.ts
@@ -22,7 +22,7 @@ const fetchUserData = async () => {
     const parsedVehicleDetails = vehicleDetailsSchema
       .array()
       .parse(vehicleDetails);
-    console.log('API CALLED');
+    console.log('API CALL');
     return { parsedUserDetails, parsedPatrolDetails, parsedVehicleDetails };
   } catch (error) {
     console.log('Error: ', error);
@@ -30,7 +30,7 @@ const fetchUserData = async () => {
 };
 
 const useUserData = () => {
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState<boolean>(true);
   const [currentUserDetails, setCurrentUserDetails] = useState<UserDetails>();
   const [fullName, setFullName] = useState<string>('');
   const [cpnzID, setCPNZID] = useState<string>('');
@@ -47,10 +47,10 @@ const useUserData = () => {
   );
   const [membersInPatrol, setMembersInPatrol] = useState<UserDetails[]>([]);
 
-  const { data } = useQuery({
+  const { data, refetch } = useQuery({
     queryKey: ['userData'],
     queryFn: fetchUserData,
-    staleTime: 300000,
+    staleTime: 300000, // data become stale after 5 minutes
   });
 
   useEffect(() => {
@@ -112,6 +112,7 @@ const useUserData = () => {
     setSelectedVehicle,
     membersInPatrol,
     setMembersInPatrol,
+    refetch,
   };
 };
 

--- a/web/src/pages/Logon.tsx
+++ b/web/src/pages/Logon.tsx
@@ -1,9 +1,9 @@
 import { useNavigate } from "react-router-dom";
-import { useForm } from "react-hook-form";
-import { zodResolver } from "@hookform/resolvers/zod";
-import { z } from "zod";
-import { Button } from "@components/ui/button";
-import { Input } from "@components/ui/input";
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { Button } from '@components/ui/button';
+import { Input } from '@components/ui/input';
 import {
   Form,
   FormControl,
@@ -11,14 +11,14 @@ import {
   FormItem,
   FormLabel,
   FormMessage,
-} from "@components/ui/form";
-import userIcon from "../assets/images/gorilla.png";
-import { useState } from "react";
-import { FaCog } from "react-icons/fa";
-import axios from "axios";
-import { Popover } from "@components/ui/popover";
-import { PopoverContent, PopoverTrigger } from "@radix-ui/react-popover";
-import { Check, ChevronsUpDown, Loader2 } from "lucide-react";
+} from '@components/ui/form';
+import userIcon from '../assets/images/gorilla.png';
+import { useEffect, useState } from 'react';
+import { FaCog } from 'react-icons/fa';
+import axios from 'axios';
+import { Popover } from '@components/ui/popover';
+import { PopoverContent, PopoverTrigger } from '@radix-ui/react-popover';
+import { Check, ChevronsUpDown, Loader2 } from 'lucide-react';
 import {
   Command,
   CommandEmpty,
@@ -26,26 +26,33 @@ import {
   CommandInput,
   CommandItem,
   CommandList,
-} from "@components/ui/command";
-import { cn } from "../lib/utils";
-import useUserData from "../hooks/useUserData";
+} from '@components/ui/command';
+import { cn } from '../lib/utils';
+import useUserData from '../hooks/useUserData';
+import { vehicleDetailsSchema } from '../schemas';
 
 export default function Logon() {
   const {
     loading,
-    setLoading,
     cpnzID,
     email,
     currentUserDetails,
     fullName,
     currentUserVehicles,
     membersInPatrol,
+    policeStation,
+    callSign,
+    patrolName,
+    mobileNumber,
   } = useUserData();
 
   const [open, setOpen] = useState(false);
 
+  type VehicleDetails = z.infer<typeof vehicleDetailsSchema>;
+
   // driverName
-  const [value, setValue] = useState<string>("");
+  const [value, setValue] = useState<string>('');
+  const [submitting, setSubmitting] = useState<boolean>(false);
 
   const membersFullName = membersInPatrol
     .filter((m) => m.cpnz_id !== currentUserDetails?.cpnz_id)
@@ -72,53 +79,64 @@ export default function Logon() {
     havePoliceRadio: z.string(),
   });
 
+  // Initalise empty form
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
-    defaultValues: async () => {
-      const response = await axios.get(
-        `${import.meta.env.VITE_API_URL}/user/getUserDetails`
-      );
-
-      const { userDetails, patrolDetails, vehicleDetails } = response.data;
-      return {
-        startTime: "",
-        endTime: "",
-        policeStationBase: userDetails.police_station.replace(/_/g, " ") || "",
-        cpCallSign: userDetails.call_sign || "",
-        patrol: patrolDetails.name || "",
-        observerName: userDetails.first_names + " " + userDetails.surname || "",
-        observerNumber: userDetails.mobile_phone || "",
-        driver: "",
-        vehicle: vehicleDetails.filter((v: any) => v.selected).name,
-        liveryOrSignage: "yes",
-        havePoliceRadio: "no",
-      };
-    },
-    mode: "onChange",
+    mode: 'onChange',
   });
 
-  const onSubmit = async (data: z.infer<typeof formSchema>) => {
-    setLoading(true);
+  // Populate default values when details have been fetched
+  useEffect(() => {
+    if (!loading) {
+      form.reset({
+        startTime: '',
+        endTime: '',
+        policeStationBase: policeStation || '',
+        cpCallSign: callSign || '',
+        patrol: patrolName || '',
+        observerName: fullName,
+        observerNumber: mobileNumber || '',
+        driver: '',
+        vehicle:
+          currentUserVehicles.find((v: VehicleDetails) => v.selected)?.name ||
+          '',
+        liveryOrSignage: 'yes',
+        havePoliceRadio: 'no',
+      });
+    }
+  }, [
+    loading,
+    policeStation,
+    callSign,
+    patrolName,
+    fullName,
+    mobileNumber,
+    currentUserVehicles,
+    form,
+  ]);
 
+  const onSubmit = async (data: z.infer<typeof formSchema>) => {
     try {
+      setSubmitting(true);
       await axios.post(`${import.meta.env.VITE_API_URL}/send-email`, {
-        recipientEmail: "jasonabc0626@gmail.com",
+        recipientEmail: 'jasonabc0626@gmail.com',
         email,
         cpnzID,
         formData: data,
       });
-
+      console.log(data);
+      setSubmitting(false);
       // Navigates to Loghome if succesfully logged on.
-      navigate("/LogHome");
+      navigate('/LogHome');
     } catch (error) {
       axios.isAxiosError(error)
         ? console.log(error.response?.data.error)
-        : console.error("Unexpected error during login:", error);
+        : console.error('Unexpected error during login:', error);
     }
   };
 
   const addGuestPatrol = () => {
-    setGuestPatrols([...guestPatrols, { name: "", number: "" }]);
+    setGuestPatrols([...guestPatrols, { name: '', number: '' }]);
   };
 
   return (
@@ -296,7 +314,7 @@ export default function Logon() {
                           <Popover open={open} onOpenChange={setOpen}>
                             <PopoverTrigger asChild>
                               <Button
-                                variant={"outline"}
+                                variant={'outline'}
                                 role="combobox"
                                 aria-expanded={open}
                                 className="w-[300px] justify-between text-md text-gray-600"
@@ -305,7 +323,7 @@ export default function Logon() {
                                   ? membersFullName.find(
                                       (member) => member.name === value
                                     )?.name
-                                  : "Select Driver"}
+                                  : 'Select Driver'}
                                 <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
                               </Button>
                             </PopoverTrigger>
@@ -325,7 +343,7 @@ export default function Logon() {
                                         onSelect={(currentValue) => {
                                           setValue(
                                             currentValue === value
-                                              ? ""
+                                              ? ''
                                               : currentValue
                                           );
                                           setOpen(false);
@@ -333,10 +351,10 @@ export default function Logon() {
                                       >
                                         <Check
                                           className={cn(
-                                            "mr-2 h-4 w-4",
+                                            'mr-2 h-4 w-4',
                                             value === member.name
-                                              ? "opacity-100"
-                                              : "opacity-0"
+                                              ? 'opacity-100'
+                                              : 'opacity-0'
                                           )}
                                         />
                                         {member.name}
@@ -510,12 +528,12 @@ export default function Logon() {
                   type="submit"
                   className="w-full bg-[#0f1363] text-white hover:bg-[#0a0d4a]"
                 >
-                  {loading ? (
+                  {submitting ? (
                     <>
-                      Submitting <Loader2 className="animate-spin ml-4" />{" "}
+                      Submitting <Loader2 className="animate-spin ml-4" />{' '}
                     </>
                   ) : (
-                    "Submit"
+                    'Submit'
                   )}
                 </Button>
               </div>

--- a/web/src/providers/AuthProvider.tsx
+++ b/web/src/providers/AuthProvider.tsx
@@ -2,48 +2,54 @@ import { useState, useEffect, PropsWithChildren } from 'react';
 import { User } from '@supabase/supabase-js';
 import { supabaseClient } from '../auth-client/SupabaseClient';
 import { AuthContext } from '../contexts/AuthContext';
+import { useQueryClient } from '@tanstack/react-query';
 
 interface ChildrenType extends PropsWithChildren {}
 
 export default function AuthProvider({ children }: ChildrenType) {
-    const [user, setUser] = useState<User>();
-    const [loading, setLoading] = useState<boolean>(true);
+  const [user, setUser] = useState<User>();
+  const [loading, setLoading] = useState<boolean>(true);
+  const queryClient = useQueryClient();
 
-    useEffect(() => {
-        const getSessionData = async function () {
-            const {
-                data: { session },
-                error,
-            } = await supabaseClient.auth.getSession();
-            if (error) {
-                console.log(`Error: ${error}`);
-            }
-            setUser(session?.user);
-            setLoading(false);
-        };
-
-        const { data: listener } = supabaseClient.auth.onAuthStateChange(
-            function (_event, session) {
-                setUser(session?.user);
-                setLoading(false);
-            }
-        );
-
-        getSessionData();
-
-        return () => {
-            listener?.subscription.unsubscribe();
-        };
-    }, []);
-
-    const value = {
-        user,
-        signOut: () => supabaseClient.auth.signOut(),
+  useEffect(() => {
+    const getSessionData = async function () {
+      const {
+        data: { session },
+        error,
+      } = await supabaseClient.auth.getSession();
+      if (error) {
+        console.log(`Error: ${error}`);
+      }
+      setUser(session?.user);
+      setLoading(false);
     };
 
-    return (
-        <AuthContext.Provider value={value}>
-            {!loading && children}
-        </AuthContext.Provider>
-    );
+    const { data: listener } = supabaseClient.auth.onAuthStateChange(function (
+      _event,
+      session
+    ) {
+      setUser(session?.user);
+      setLoading(false);
+    });
+
+    getSessionData();
+
+    return () => {
+      listener?.subscription.unsubscribe();
+    };
+  }, []);
+
+  const value = {
+    user,
+    signOut: () => {
+      queryClient.removeQueries();
+      supabaseClient.auth.signOut();
+    },
+  };
+
+  return (
+    <AuthContext.Provider value={value}>
+      {!loading && children}
+    </AuthContext.Provider>
+  );
 }


### PR DESCRIPTION
## Context

Every time useUserData hook is called, a request is send to fetch user details. To prevent multiple requests and improve UX, we can cache this data to be used without re-requesting from the endpoint.

## What Changed?

- Implemented caching using useQuery
- Added usage to VehicleDetailsForm when user updates vehicles, it will refetch updated data
- Integrated into LogonForm

## How To Review

1. web/src/hooks/useUserData.ts
2. web/src/components/profile/VehicleDetailsForm.tsx
3. web/src/pages/Logon.tsx

## Testing

Navigated between multiple pages to ensure API was not being called when data had been cached

## Risks

N/A

## Notes
Need to refactor Logon page 💀 