### PR TITLE
Refactor/clean use user data hook

### DIFF
--- a/web/src/components/logon/LogonForm.tsx
+++ b/web/src/components/logon/LogonForm.tsx
@@ -33,10 +33,12 @@ import axios from "axios";
 import { cn } from "../../lib/utils";
 
 interface LogonFormProps {
-  currentUserDetails?: z.infer<typeof userDetailsSchema>;
+  currentUserDetails: z.infer<typeof userDetailsSchema>;
   currentUserVehicles: z.infer<typeof vehicleDetailsSchema>[];
-  membersInPatrol: z.infer<typeof patrolDetailsSchema>;
+  patrolDetails: z.infer<typeof patrolDetailsSchema>;
 }
+
+type VehicleDetails = z.infer<typeof vehicleDetailsSchema>;
 
 export default function LogonForm(props: LogonFormProps) {
   const [driver, setDriver] = useState<string>("");
@@ -47,8 +49,8 @@ export default function LogonForm(props: LogonFormProps) {
   const [submitting, setSubmitting] = useState<boolean>(false);
   const navigate = useNavigate();
 
-  const membersFullName = props.membersInPatrol["members_dev"]
-    .filter((m) => m.cpnz_id !== props.currentUserDetails?.cpnz_id)
+  const membersFullName = props.patrolDetails["members_dev"]
+    .filter((m) => m.cpnz_id !== props.currentUserDetails.cpnz_id)
     .map((m) => ({
       name: `${m.first_names} ${m.surname}`,
     }));
@@ -56,7 +58,6 @@ export default function LogonForm(props: LogonFormProps) {
   const addGuestPatrol = () => {
     setGuestPatrols([...guestPatrols, { name: "", number: "" }]);
   };
-  type VehicleDetails = z.infer<typeof vehicleDetailsSchema>;
 
   const formSchema = z.object({
     startTime: z.string().min(1),
@@ -77,14 +78,14 @@ export default function LogonForm(props: LogonFormProps) {
     defaultValues: {
       startTime: "",
       endTime: "",
-      policeStationBase: props.currentUserDetails?.police_station.replace(
+      policeStationBase: props.currentUserDetails.police_station.replace(
         /_/g,
         " "
       ),
       cpCallSign: props.currentUserDetails?.call_sign,
-      patrol: props.membersInPatrol.name.replace(/_/g, " "),
-      observerName: `${props.currentUserDetails?.first_names} ${props.currentUserDetails?.surname}`,
-      observerNumber: props.currentUserDetails?.mobile_phone,
+      patrol: props.patrolDetails.name.replace(/_/g, " "),
+      observerName: `${props.currentUserDetails.first_names} ${props.currentUserDetails.surname}`,
+      observerNumber: props.currentUserDetails.mobile_phone,
       driver: "",
       vehicle:
         (props.currentUserVehicles.find((v: VehicleDetails) => v.selected)
@@ -99,26 +100,26 @@ export default function LogonForm(props: LogonFormProps) {
   });
 
   const onSubmit = async (data: z.infer<typeof formSchema>) => {
-      try {
-        setSubmitting(true);
-        await axios.post(`${import.meta.env.VITE_API_URL}/send-email`, {
-          recipientEmail: "jasonabc0626@gmail.com",
-          email: props.currentUserDetails?.email,
-          cpnzID: props.currentUserDetails?.cpnz_id,
-          formData: data,
-          driver: props.membersInPatrol["members_dev"].find(
-            (m) => m.first_names + " " + m.surname === driver
-          ),
-        });
-        console.log(data);
-        setSubmitting(false);
-        // Navigates to Loghome if succesfully logged on.
-        navigate("/LogHome");
-      } catch (error) {
-        axios.isAxiosError(error)
-          ? console.log(error.response?.data.error)
-          : console.error("Unexpected error during login:", error);
-      }
+    try {
+      setSubmitting(true);
+      await axios.post(`${import.meta.env.VITE_API_URL}/send-email`, {
+        recipientEmail: "jasonabc0626@gmail.com",
+        email: props.currentUserDetails.email,
+        cpnzID: props.currentUserDetails.cpnz_id,
+        formData: data,
+        driver: props.patrolDetails["members_dev"].find(
+          (m) => m.first_names + " " + m.surname === driver
+        ),
+      });
+      console.log(data);
+      setSubmitting(false);
+      // Navigates to Loghome if succesfully logged on.
+      navigate("/LogHome");
+    } catch (error) {
+      axios.isAxiosError(error)
+        ? console.log(error.response?.data.error)
+        : console.error("Unexpected error during login:", error);
+    }
   };
   return (
     <Form {...form}>

--- a/web/src/components/profile/PatrolDetailsForm.tsx
+++ b/web/src/components/profile/PatrolDetailsForm.tsx
@@ -1,13 +1,22 @@
 import { FormItem, FormLabel, Form } from '@components/ui/form';
 import { Input } from '@components/ui/input';
-import useUserData from '../../hooks/useUserData';
-import { formSchema } from '../../schemas';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { useForm } from 'react-hook-form';
-import { z } from 'zod';
+import {
+  formSchema,
+  patrolDetailsSchema,
+  userDetailsSchema,
+} from "../../schemas";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
 
-export default function PatrolDetailsForm() {
-  const { callSign, patrolName, policeStation } = useUserData();
+interface PatrolDetailsFormProps {
+  currentUserDetails: z.infer<typeof userDetailsSchema>;
+  patrolDetails: z.infer<typeof patrolDetailsSchema>;
+}
+
+export default function PatrolDetailsForm(props: PatrolDetailsFormProps) {
+  const { call_sign, police_station } = props.currentUserDetails;
+  const { name } = props.patrolDetails;
 
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
@@ -23,7 +32,7 @@ export default function PatrolDetailsForm() {
             type="text"
             id="cpCallSign"
             name="cpCallSign"
-            value={callSign}
+            value={call_sign}
             disabled
             className="rounded-md px-3 py-2 border-[#CBD5E1]"
           />
@@ -34,7 +43,7 @@ export default function PatrolDetailsForm() {
             type="text"
             id="patrol"
             name="patrol"
-            value={patrolName}
+            value={name.replace(/_/g, " ")}
             disabled
             className="rounded-md px-3 py-2 border-[#CBD5E1]"
           />
@@ -46,7 +55,7 @@ export default function PatrolDetailsForm() {
             id="policeBase"
             name="policeBase"
             disabled
-            value={policeStation}
+            value={police_station.replace(/_/g, " ")}
             className="rounded-md px-3 py-2 border-[#CBD5E1]"
           />
         </FormItem>

--- a/web/src/components/profile/UserDetailsForm.tsx
+++ b/web/src/components/profile/UserDetailsForm.tsx
@@ -2,38 +2,44 @@ import { Button } from '@components/ui/button';
 import { Input } from '@components/ui/input';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Form, FormItem, FormLabel } from '@components/ui/form';
-import { z } from 'zod';
-import useUserData from '../../hooks/useUserData';
-import { useEffect, useState } from 'react';
-import { supabaseClient as supabase } from '../../auth-client/SupabaseClient';
-import { useForm } from 'react-hook-form';
-import { formSchema } from '../../schemas';
+import { z } from "zod";
+import useUserData from "../../hooks/useUserData";
+import { useEffect, useState } from "react";
+import { supabaseClient as supabase } from "../../auth-client/SupabaseClient";
+import { useForm } from "react-hook-form";
+import { formSchema, userDetailsSchema } from "../../schemas";
 
-export default function UserDetailsForm() {
+interface UserDetailsFormProps {
+  currentUserDetails: z.infer<typeof userDetailsSchema>;
+}
+
+export default function UserDetailsForm(props: UserDetailsFormProps) {
   const [editable, setEditable] = useState<boolean>(false);
-  const [errorMessage, setErrorMessage] = useState<string>('');
-  const { fullName, cpnzID, email, mobileNumber } = useUserData();
-  const [password, setPassword] = useState<string>('');
-  const [confirmPassword, setConfirmPassword] = useState<string>('');
+  const [errorMessage, setErrorMessage] = useState<string>("");
+  const [password, setPassword] = useState<string>("");
+  const [confirmPassword, setConfirmPassword] = useState<string>("");
+  const { fullName } = useUserData();
+
+  const { cpnz_id, email, mobile_phone } = props.currentUserDetails;
 
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
     defaultValues: {
-      cpnzID: '',
-      password: '',
-      confirmPassword: '',
+      cpnzID: "",
+      password: "",
+      confirmPassword: "",
     },
   });
 
   useEffect(() => {
     if (
-      password !== '' &&
-      confirmPassword !== '' &&
+      password !== "" &&
+      confirmPassword !== "" &&
       password !== confirmPassword
     ) {
-      setErrorMessage('Passwords do not match');
+      setErrorMessage("Passwords do not match");
     } else {
-      setErrorMessage('');
+      setErrorMessage("");
     }
   }, [password, confirmPassword]);
 
@@ -49,15 +55,15 @@ export default function UserDetailsForm() {
     if (error) {
       setErrorMessage(`Error changing password: ${error}`);
     }
-    setPassword('');
-    setConfirmPassword('');
+    setPassword("");
+    setConfirmPassword("");
     setEditable(false);
   };
 
   const handleCancel = () => {
     setEditable(false);
-    setPassword('');
-    setConfirmPassword('');
+    setPassword("");
+    setConfirmPassword("");
   };
 
   return (
@@ -82,7 +88,7 @@ export default function UserDetailsForm() {
                 type="text"
                 id="id"
                 name="id"
-                value={cpnzID}
+                value={cpnz_id}
                 disabled
                 className="rounded-md border-[#CBD5E1]"
               />
@@ -110,7 +116,7 @@ export default function UserDetailsForm() {
                 type="text"
                 id="mobileNumber"
                 name="mobileNumber"
-                value={mobileNumber}
+                value={mobile_phone}
                 disabled
                 className="rounded-md border-[#CBD5E1]"
               />
@@ -132,7 +138,7 @@ export default function UserDetailsForm() {
               </FormItem>
               <FormItem className="basis-1/2">
                 <FormLabel htmlFor="confirmPassword" className="font-semibold">
-                  Confirm New Password{' '}
+                  Confirm New Password{" "}
                 </FormLabel>
                 <Input
                   type="password"
@@ -165,7 +171,7 @@ export default function UserDetailsForm() {
               Save
             </Button>
             <Button
-              variant={'outline'}
+              variant={"outline"}
               onClick={handleCancel}
               className="border-cpnz-blue-900 mt-4 w-28"
             >

--- a/web/src/hooks/useUserData.ts
+++ b/web/src/hooks/useUserData.ts
@@ -31,23 +31,12 @@ const fetchUserData = async () => {
 };
 
 const useUserData = () => {
-  const [loading, setLoading] = useState<boolean>(true);
   const [currentUserDetails, setCurrentUserDetails] = useState<UserDetails>();
   const [patrolDetails, setPatrolDetails] = useState<PatrolDetails>();
   const [fullName, setFullName] = useState<string>("");
-  const [cpnzID, setCPNZID] = useState<string>("");
-  const [email, setEmail] = useState<string>("");
-  const [mobileNumber, setMobileNumber] = useState<string>("");
-  const [callSign, setCallSign] = useState<string>("");
-  const [patrolName, setPatrolName] = useState<string>("");
-  const [policeStation, setPoliceStation] = useState<string>("");
   const [currentUserVehicles, setCurrentUserVehicles] = useState<
     VehicleDetails[]
   >([]);
-  const [selectedVehicle, setSelectedVehicle] = useState<VehicleDetails | null>(
-    null
-  );
-  const [membersInPatrol, setMembersInPatrol] = useState<UserDetails[]>([]);
 
   const { data, refetch } = useQuery({
     queryKey: ["userData"],
@@ -62,59 +51,27 @@ const useUserData = () => {
 
       setCurrentUserDetails(parsedUserDetails);
       setPatrolDetails(parsedPatrolDetails);
-      setCallSign(parsedUserDetails.call_sign);
-      setPatrolName(parsedPatrolDetails.name);
-      setPoliceStation(parsedUserDetails.police_station.replace(/_/g, " "));
-      setEmail(parsedUserDetails.email);
-      setCPNZID(parsedUserDetails.cpnz_id);
-      setMobileNumber(parsedUserDetails.mobile_phone);
+
       setFullName(
         `${parsedUserDetails.first_names} ${parsedUserDetails.surname}`
       );
 
       if (parsedVehicleDetails.length === 0) {
-        setSelectedVehicle(null);
         setCurrentUserVehicles([]);
       } else {
-        setSelectedVehicle(
-          parsedVehicleDetails.find((vehicle) => vehicle.selected) || null
-        );
         const reorderedVehicles = [
           ...parsedVehicleDetails.filter((vehicle) => vehicle.selected),
           ...parsedVehicleDetails.filter((vehicle) => !vehicle.selected),
         ];
         setCurrentUserVehicles(reorderedVehicles);
       }
-      setMembersInPatrol(parsedPatrolDetails.members_dev);
-      setLoading(false);
     }
   }, [data]);
 
   return {
-    loading,
-    setLoading,
     currentUserDetails,
-    setCurrentUserDetails,
     fullName,
-    setFullName,
-    cpnzID,
-    setCPNZID,
-    email,
-    setEmail,
-    mobileNumber,
-    setMobileNumber,
-    callSign,
-    setCallSign,
-    patrolName,
-    setPatrolName,
-    policeStation,
-    setPoliceStation,
     currentUserVehicles,
-    setCurrentUserVehicles,
-    selectedVehicle,
-    setSelectedVehicle,
-    membersInPatrol,
-    setMembersInPatrol,
     patrolDetails,
     refetch,
   };

--- a/web/src/pages/Logon.tsx
+++ b/web/src/pages/Logon.tsx
@@ -80,7 +80,7 @@ export default function Logon() {
             <LogonForm
               currentUserDetails={formData.currentUserDetails}
               currentUserVehicles={formData.currentUserVehicles}
-              patrolDetails={formData.currentPatrolDetails}
+              patrolDetails={formData.patrolDetails}
             />
           </div>
         </div>

--- a/web/src/pages/Logon.tsx
+++ b/web/src/pages/Logon.tsx
@@ -12,7 +12,7 @@ import {
 } from "../schemas";
 
 interface FormData {
-  currentUserDetails?: z.infer<typeof userDetailsSchema>;
+  currentUserDetails: z.infer<typeof userDetailsSchema>;
   currentUserVehicles: z.infer<typeof vehicleDetailsSchema>[];
   currentPatrolDetails: z.infer<typeof patrolDetailsSchema>;
 }
@@ -55,36 +55,36 @@ export default function Logon() {
     );
   }
 
-  return (
-    <div className=" bg-white flex items-center justify-center">
-      <div className="max-w-6xl w-full">
-        <div className="bg-[#EEF6FF] px-8 py-6 flex items-center justify-between">
-          <div className="flex items-center">
-            <img
-              src={userIcon}
-              alt="User Icon"
-              className="w-16 h-16 mr-4 rounded-full"
-            />
-            <h2 className="text-2xl font-bold">Welcome back, {fullName}</h2>
+  if (formData) {
+    return (
+      <div className=" bg-white flex items-center justify-center">
+        <div className="max-w-6xl w-full">
+          <div className="bg-[#EEF6FF] px-8 py-6 flex items-center justify-between">
+            <div className="flex items-center">
+              <img
+                src={userIcon}
+                alt="User Icon"
+                className="w-16 h-16 mr-4 rounded-full"
+              />
+              <h2 className="text-2xl font-bold">Welcome back, {fullName}</h2>
+            </div>
+            <button className="flex items-center">
+              <span className="mr-2 text-lg font-semibold">Settings</span>
+              <FaCog className="text-2xl text-gray-400 cursor-pointer hover:text-gray-200 transition-colors duration-300" />
+            </button>
           </div>
-          <button className="flex items-center">
-            <span className="mr-2 text-lg font-semibold">Settings</span>
-            <FaCog className="text-2xl text-gray-400 cursor-pointer hover:text-gray-200 transition-colors duration-300" />
-          </button>
-        </div>
-        <div className="bg-white p-8">
-          <h3 className="text-3xl font-bold mb-8 text-center">
-            Shift Log-on Form
-          </h3>
-          <LogonForm
-            currentUserDetails={formData?.currentUserDetails}
-            currentUserVehicles={formData?.currentUserVehicles || []}
-            membersInPatrol={
-              formData?.currentPatrolDetails ?? { name: "", members_dev: [] }
-            }
-          />
+          <div className="bg-white p-8">
+            <h3 className="text-3xl font-bold mb-8 text-center">
+              Shift Log-on Form
+            </h3>
+            <LogonForm
+              currentUserDetails={formData.currentUserDetails}
+              currentUserVehicles={formData.currentUserVehicles}
+              patrolDetails={formData.currentPatrolDetails}
+            />
+          </div>
         </div>
       </div>
-    </div>
-  );
+    );
+  }
 }

--- a/web/src/pages/Profile.tsx
+++ b/web/src/pages/Profile.tsx
@@ -3,8 +3,53 @@ import BottomNavBar from '@components/BottomNavBar';
 import PatrolDetailsForm from '@components/profile/PatrolDetailsForm';
 import UserDetailsForm from '@components/profile/UserDetailsForm';
 import VehicleDetailsForm from '@components/profile/VehicleDetailsForm';
+import useUserData from "../hooks/useUserData";
+import { Loader2 } from "lucide-react";
+import { useEffect, useState } from "react";
+import { z } from "zod";
+import {
+  userDetailsSchema,
+  vehicleDetailsSchema,
+  patrolDetailsSchema,
+} from "../schemas";
+
+interface ProfileData {
+  currentUserDetails: z.infer<typeof userDetailsSchema>;
+  currentUserVehicles: z.infer<typeof vehicleDetailsSchema>[];
+  currentPatrolDetails: z.infer<typeof patrolDetailsSchema>;
+}
 
 export default function Profile() {
+  const [loading, setLoading] = useState<boolean>(true);
+  const [profileData, setProfileData] = useState<ProfileData>();
+  const { currentUserDetails, patrolDetails, currentUserVehicles } =
+    useUserData();
+
+  useEffect(() => {
+    if (currentUserDetails && currentUserVehicles && patrolDetails) {
+      const profileDataObject = {
+        currentUserDetails,
+        currentUserVehicles,
+        currentPatrolDetails: {
+          name: patrolDetails.name,
+          members_dev: patrolDetails.members_dev,
+        },
+      };
+      setProfileData(profileDataObject);
+      setLoading(false);
+    }
+  }, [currentUserDetails, currentUserVehicles, patrolDetails]);
+
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center h-screen">
+        <div className="flex flex-col items-center">
+          <Loader2 className="animate-spin" />
+          <p>Loading...</p>
+        </div>
+      </div>
+    );
+  }
   return (
     <div className="text-center flex-col min-h-screen flex max-w-3xl mx-auto">
       <div className="bg-[#eef6ff] h-28 mb-4 pl-8 pt-4">
@@ -19,9 +64,12 @@ export default function Profile() {
           <h1 className="font-bold text-left pt-2 text-2xl">Profile</h1>
         </div>
       </div>
-      <UserDetailsForm />
-      <PatrolDetailsForm />
-      <VehicleDetailsForm />
+      <UserDetailsForm currentUserDetails={profileData!.currentUserDetails} />
+      <PatrolDetailsForm
+        currentUserDetails={profileData!.currentUserDetails}
+        patrolDetails={profileData!.currentPatrolDetails}
+      />
+      <VehicleDetailsForm currentUserVehicles={currentUserVehicles} />
       <BottomNavBar />
     </div>
   );

--- a/web/src/pages/Profile.tsx
+++ b/web/src/pages/Profile.tsx
@@ -27,7 +27,7 @@ export default function Profile() {
 
   useEffect(() => {
     if (currentUserDetails && currentUserVehicles && patrolDetails) {
-      const profileDataObject = {
+      const profileDataObject: ProfileData = {
         currentUserDetails,
         currentUserVehicles,
         currentPatrolDetails: {
@@ -50,27 +50,32 @@ export default function Profile() {
       </div>
     );
   }
-  return (
-    <div className="text-center flex-col min-h-screen flex max-w-3xl mx-auto">
-      <div className="bg-[#eef6ff] h-28 mb-4 pl-8 pt-4">
-        <div>
-          <img
-            src={placeholder}
-            alt="placeholder"
-            className="rounded-full w-10 h-10"
-          />
+
+  if (profileData) {
+    return (
+      <div className="text-center flex-col min-h-screen flex max-w-3xl mx-auto">
+        <div className="bg-[#eef6ff] h-28 mb-4 pl-8 pt-4">
+          <div>
+            <img
+              src={placeholder}
+              alt="placeholder"
+              className="rounded-full w-10 h-10"
+            />
+          </div>
+          <div>
+            <h1 className="font-bold text-left pt-2 text-2xl">Profile</h1>
+          </div>
         </div>
-        <div>
-          <h1 className="font-bold text-left pt-2 text-2xl">Profile</h1>
-        </div>
+        <UserDetailsForm currentUserDetails={profileData.currentUserDetails} />
+        <PatrolDetailsForm
+          currentUserDetails={profileData.currentUserDetails}
+          patrolDetails={profileData.currentPatrolDetails}
+        />
+        <VehicleDetailsForm
+          currentUserVehicles={profileData.currentUserVehicles}
+        />
+        <BottomNavBar />
       </div>
-      <UserDetailsForm currentUserDetails={profileData!.currentUserDetails} />
-      <PatrolDetailsForm
-        currentUserDetails={profileData!.currentUserDetails}
-        patrolDetails={profileData!.currentPatrolDetails}
-      />
-      <VehicleDetailsForm currentUserVehicles={currentUserVehicles} />
-      <BottomNavBar />
-    </div>
-  );
+    );
+  }
 }


### PR DESCRIPTION
## Context

The useUserData hook was returning various state and set state variables, many of which were not used. 

## What Changed?
- The useUserData hook now returns consolidated objects (currentUserDetails, currentUserVehicles, and patrolDetails) instead of each individual key of these objects. 
- Callers of the useUserData hook will now destructure the necessary data from the returned objects, leading to cleaner and more maintainable code.
- Integrated changes into Profile and Logon page

## How To Review

1. web/src/hooks/useUserData.ts
2. web/src/pages/Logon.tsx
3. web/src/pages/Profile.tsx

## Testing
Updated any component that uses the useUserData hook to match the new structure.
Ensured all functionality dependent on data is working as expected.