### PR TITLE
Feat/use draft status hook

### DIFF
--- a/web/src/hooks/useDraftStatus.ts
+++ b/web/src/hooks/useDraftStatus.ts
@@ -1,0 +1,6 @@
+const useDraftStatus = () => {
+  const draft = localStorage.getItem("observations");
+  return draft !== null && draft !== "[]";
+};
+
+export default useDraftStatus;

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -16,6 +16,7 @@ import SignoutButton from "@components/SignoutButton";
 import BottomNavBar from "@components/BottomNavBar";
 import SmallInfoButton from "@components/ui/SmallInfoButton";
 import LargeInfoButton from "@components/ui/LargeInfoButton";
+import useDraftStatus from "../hooks/useDraftStatus";
 
 const reportsDetailsSchema = z.object({
   message: z.string(),
@@ -37,10 +38,15 @@ export default function Home() {
   const navigate = useNavigate();
   const [data, setData] = useState<reportsDetails>();
   const [id, setId] = useState<number>();
+  const isDraft: boolean = useDraftStatus();
 
   // Function to navigate to the logon page when new report button is clicked
   const handleNewReport = () => {
     navigate("/logon");
+  };
+
+  const handleDraftReport = () => {
+    navigate("/report");
   };
 
   useEffect(() => {
@@ -82,13 +88,16 @@ export default function Home() {
         <FaCog className="text-2xl text-gray-400 cursor-pointer hover:text-gray-200 transition-colors duration-300" />
       </div>
       <div className="max-w-800 mx-auto px-8 my-8">
-        <LargeInfoButton
-          heading={"Draft report detected"}
-          description={"You have a report you haven't submitted."}
-          className="bg-[#EEF6FF] p-4 rounded-lg shadow-md mb-6"
-          iconDescription={"Finish your report?"}
-          variant={"light"}
-        />
+        {isDraft && (
+          <LargeInfoButton
+            heading={"Draft report detected"}
+            description={"You have a report you haven't submitted."}
+            className="bg-[#EEF6FF] p-4 rounded-lg shadow-md mb-6"
+            iconDescription={"Finish your report?"}
+            onClick={handleDraftReport}
+            variant={"light"}
+          />
+        )}
         <LargeInfoButton
           className="bg-[#0F1363] p-4 rounded-lg shadow-md mb-6 text-left"
           heading={"Log on to start a new shift"}

--- a/web/src/pages/LogHome.tsx
+++ b/web/src/pages/LogHome.tsx
@@ -3,13 +3,19 @@ import { FaCog, FaClipboardList } from "react-icons/fa";
 import BottomNavBar from "@components/BottomNavBar";
 import LargeInfoButton from "@components/ui/LargeInfoButton";
 import SmallInfoButton from "@components/ui/SmallInfoButton";
+import useDraftStatus from "../hooks/useDraftStatus";
 
 export default function ReportSummary() {
   const navigate = useNavigate();
+  const isDraft: boolean = useDraftStatus();
 
   // Function to navigate to the new report page
   const handleNewReport = () => {
     navigate("/Report");
+  };
+
+  const handleDraftReport = () => {
+    navigate("/report");
   };
 
   return (
@@ -23,13 +29,16 @@ export default function ReportSummary() {
         <FaCog className="text-2xl text-black cursor-pointer hover:text-gray-200 transition-colors duration-300" />
       </div>
       <div className="max-w-800 mx-auto px-8 my-8">
-        <LargeInfoButton
-          heading={"Draft report detected"}
-          description={"You have a report you haven't submitted."}
-          className="bg-[#0F1363] p-4 rounded-lg shadow-md mb-6"
-          iconDescription={"Finish your report?"}
-          variant={"dark"}
-        />
+        {isDraft && (
+          <LargeInfoButton
+            heading={"Draft report detected"}
+            description={"You have a report you haven't submitted."}
+            className="bg-[#0F1363] p-4 rounded-lg shadow-md mb-6"
+            iconDescription={"Finish your report?"}
+            onClick={handleDraftReport}
+            variant={"dark"}
+          />
+        )}
         <LargeInfoButton
           heading={"Report your observations"}
           description={"Use this to report your observations during your shift"}


### PR DESCRIPTION
## Context

Introduces a new hook, `useDraftStatus`, to conditionally render the draft report detected button on `Home` and `LogHome` pages.

## What Changed?

- New Hook -`useDraftStatus`: Created a new React hook that checks for the presence of draft observations in local storage. Returns a boolean value.
- Implemented the `useDraftStatus` hook in the `Home` and `LogHome` pages. These components now conditionally render a button for detecting draft reports based on the hook's return value.

## How To Review

1. web/src/hooks/useDraftStatus.ts
2. web/src/pages/Home.tsx
3. web/src/pages/LogHome.tsx

## Testing

- Cleared local storage and accessed the Home and LogHome pages to confirm that the draft detected button does not appear.
-  Added dummy draft data into `Reports` page then navigated to `Home` and `LogHome` to verify that the draft detected button appears as expected.