### PR TITLE
Feat/back up pub/sub auth

### DIFF
--- a/api/gmail_util/listenToMessage.ts
+++ b/api/gmail_util/listenToMessage.ts
@@ -3,26 +3,26 @@ import { getHistoryRecords } from '../controller/gmailController';
 import prisma from '../db/database';
 
 
-const gCloudClientEmail = process.env.GOOGLE_CLOUD_CLIENT_EMAIL
-const gCloudPrivateKeyJSON = JSON.parse(process.env.GOOGLE_CLOUD_PRIVATE_KEY|| '{}');
-const gCloudPrivateKey = gCloudPrivateKeyJSON.private_key
-const gCloudProjectId = process.env.GOOGLE_CLOUD_PROJECT_ID;
-
-if(!gCloudClientEmail || !gCloudPrivateKey || !gCloudProjectId) {
-    console.log("Error: please ensure [GOOGLE_CLOUD_CLIENT_EMAIL], [GOOGLE_CLOUD_PRIVATE_KEY] or [GOOGLE_CLOUD_PROJECT_ID] .env variables are properly stored")
-}
-
-const pubSubClient = new PubSub({
-    projectId: gCloudProjectId,
-    credentials: {
-        client_email: gCloudClientEmail,
-        private_key: gCloudPrivateKey
-    }
-});
-
 function listenForMessages(subscriptionNameOrId: string): void {
     // References an existing subscription
     try {
+        const gCloudClientEmail = process.env.GOOGLE_CLOUD_CLIENT_EMAIL
+        const gCloudPrivateKeyJSON = JSON.parse(process.env.GOOGLE_CLOUD_PRIVATE_KEY || '{}');
+        const gCloudPrivateKey = gCloudPrivateKeyJSON.private_key
+        const gCloudProjectId = process.env.GOOGLE_CLOUD_PROJECT_ID;
+
+        if (!gCloudClientEmail || !gCloudPrivateKey || !gCloudProjectId) {
+            throw new Error("Error: please ensure [GOOGLE_CLOUD_CLIENT_EMAIL], [GOOGLE_CLOUD_PRIVATE_KEY] or [GOOGLE_CLOUD_PROJECT_ID] .env variables are properly stored")
+        }
+
+        const pubSubClient = new PubSub({
+            projectId: gCloudProjectId,
+            credentials: {
+                client_email: gCloudClientEmail,
+                private_key: gCloudPrivateKey
+            }
+        });
+
         const subscription = pubSubClient.subscription(subscriptionNameOrId);
 
         // Create an event handler to handle messages

--- a/api/gmail_util/listenToMessage.ts
+++ b/api/gmail_util/listenToMessage.ts
@@ -2,7 +2,23 @@ import { PubSub, Message } from '@google-cloud/pubsub';
 import { getHistoryRecords } from '../controller/gmailController';
 import prisma from '../db/database';
 
-const pubSubClient = new PubSub();
+
+const gCloudClientEmail = process.env.GOOGLE_CLOUD_CLIENT_EMAIL
+const gCloudPrivateKeyJSON = JSON.parse(process.env.GOOGLE_CLOUD_PRIVATE_KEY|| '{}');
+const gCloudPrivateKey = gCloudPrivateKeyJSON.private_key
+const gCloudProjectId = process.env.GOOGLE_CLOUD_PROJECT_ID;
+
+if(!gCloudClientEmail || !gCloudPrivateKey || !gCloudProjectId) {
+    console.log("Error: please ensure [GOOGLE_CLOUD_CLIENT_EMAIL], [GOOGLE_CLOUD_PRIVATE_KEY] or [GOOGLE_CLOUD_PROJECT_ID] .env variables are properly stored")
+}
+
+const pubSubClient = new PubSub({
+    projectId: gCloudProjectId,
+    credentials: {
+        client_email: gCloudClientEmail,
+        private_key: gCloudPrivateKey
+    }
+});
 
 function listenForMessages(subscriptionNameOrId: string): void {
     // References an existing subscription
@@ -31,10 +47,10 @@ function listenForMessages(subscriptionNameOrId: string): void {
 
             const historyId: bigint | null | undefined = fetchHistoryId?.history_id
 
-            if(!historyId) {
+            if (!historyId) {
                 throw new Error('Failed to fetch gmail history ID')
             }
-            
+
             const success = await getHistoryRecords(historyId);
 
             if (success) {
@@ -43,8 +59,9 @@ function listenForMessages(subscriptionNameOrId: string): void {
         };
 
         subscription.on('message', messageHandler);
-    } catch (err) {
-        console.log('Error: failed to pull a message from gmail')
+    } catch (err: any) {
+        console.log('Error - failed to pull a message from gmail:')
+        console.log(err.message)
     }
 
 }


### PR DESCRIPTION
## Context

<!-- Include contextual info that can't be found in the linked issue. Why are you making this change? -->

We are unable to store the whole json keys file in production safely, and switching over to use Workload Identity Federation (WIF) as the method to get access to google cloud resources. However, its documentation on how to use it in github as workflow provider is limited and this approach is itself harder to implement than the others. 

Therefore, I figured out a alternative way to get through the authentication, although it might not be the recommended method as it is not mentioned in gcloud documentation, but since it only requires env variable, which still deemed safe in my opinion.

_**--- If you want to test it, ask me to send the new env variable in discord. ---**
**--- This is a back up plan to get authenticated to pub/sub. ---**_
**_--- Only merge this, if the WIF approach does not work properly in the end ---_**



## What Changed?
Change the way to initialize a pubSub instance in `listenToMessage.ts`

<!-- What changes did you make? -->

## How To Review

<!-- What (rough) order should the reviewer view your files? -->

switch to this branch, run the codes and try to log on.


## Testing
Tested locally, works fine in receiving and fetching messages from gmail inbox.
<!-- What testing did you do, if any? -->

## Risks
Google cloud might block such way to authenticate and get access to its resources in the future, as it is not listed in any of its _"easy-to-find"_ documentations, however, they also might not easily block any of its auth approach, as many legacy systems might be still depedent on it (Not sure, I guess)
<!-- Where should the reviewer focus on (if any)? -->

## Notes
N/A