### PR TITLE
Refactor: Move police recipient email to env variable for both logon and amendment

### DIFF
--- a/api/controller/emailController.ts
+++ b/api/controller/emailController.ts
@@ -5,7 +5,8 @@ import { Resend } from "resend";
 import { LogonStatus } from "@prisma/client";
 
 const EMAIL_API_KEY: string = process.env.RESEND_API_KEY as string;
-const CPNZ_APP_EMAIL = "ecc@cpnz.org.nz";
+const CPNZ_APP_EMAIL = process.env.CPNZ_EMAIL_TEST
+const POLICE_EMAIL = process.env.CPNZ_ECC_RECIPIENT_EMAIL;
 const resend = new Resend(EMAIL_API_KEY);
 
 function toObject(data: any) {
@@ -54,13 +55,14 @@ export const userDetailsSchema = z.object({
 export const sendShiftRequest = async (req: Request, res: Response) => {
   const emailSchema = z.object({
     email: z.string(),
-    recipientEmail: z.string(),
     cpnzID: z.string(),
     formData: formSchema,
     driver: userDetailsSchema,
   });
 
   const parseResult = emailSchema.safeParse(req.body);
+  const recipientEmail = POLICE_EMAIL;
+  console.log(recipientEmail)
 
   if (!parseResult.success) {
     //return res.status(400).json({ error: parseResult.error.flatten() });
@@ -130,7 +132,6 @@ export const sendShiftRequest = async (req: Request, res: Response) => {
 
     const {
       email,
-      recipientEmail,
       cpnzID,
       formData,
       driver,
@@ -191,7 +192,7 @@ export const sendShiftRequest = async (req: Request, res: Response) => {
     </p>
   </div>`,
     });
-
+    console.log(data)
     res.status(200).json({ message: "Email sent successfully" });
   } catch (error) {
     res.status(400).json(error);
@@ -262,8 +263,13 @@ export const handleAmendment = async (req: Request, res: Response) => {
 
     // Send the amendment email
     try {
+      const recipientEmail = POLICE_EMAIL;
+
+      if(!recipientEmail) {
+        throw new Error('Please ensure recipient email is provided. e.g. Police-ECC email address')
+      }
       const emailResponse = await sendAmendEmail(
-        "jasonabc0626@gmail.com",
+        recipientEmail,
         text,
         event_no
       );

--- a/api/controller/emailController.ts
+++ b/api/controller/emailController.ts
@@ -62,7 +62,6 @@ export const sendShiftRequest = async (req: Request, res: Response) => {
 
   const parseResult = emailSchema.safeParse(req.body);
   const recipientEmail = POLICE_EMAIL;
-  console.log(recipientEmail)
 
   if (!parseResult.success) {
     //return res.status(400).json({ error: parseResult.error.flatten() });
@@ -192,7 +191,6 @@ export const sendShiftRequest = async (req: Request, res: Response) => {
     </p>
   </div>`,
     });
-    console.log(data)
     res.status(200).json({ message: "Email sent successfully" });
   } catch (error) {
     res.status(400).json(error);

--- a/web/src/components/logon/LogonForm.tsx
+++ b/web/src/components/logon/LogonForm.tsx
@@ -116,11 +116,8 @@ export default function LogonForm(props: LogonFormProps) {
       setSubmitting(true);
 
       await axios.post(`${import.meta.env.VITE_API_URL}/email/`, {
-         // recipientEmail: "cpnzecc@police.govt.nz",
-        recipientEmail: "jasonabc0626@gmail.com",
-        // recipientEmail: "leetony347@yahoo.com",
-        //recipientEmail: "jbac208@auckland.ac.nz",
-        //recipientEmail: "makjoshua2003@gmail.com",
+        //  recipientEmail: "cpnzecc@police.govt.nz",
+        recipientEmail: "leetony347@yahoo.com",
         email: props.currentUserDetails.email,
         cpnzID: props.currentUserDetails.cpnz_id,
         formData: data,

--- a/web/src/components/logon/LogonForm.tsx
+++ b/web/src/components/logon/LogonForm.tsx
@@ -116,8 +116,6 @@ export default function LogonForm(props: LogonFormProps) {
       setSubmitting(true);
 
       await axios.post(`${import.meta.env.VITE_API_URL}/email/`, {
-        //  recipientEmail: "cpnzecc@police.govt.nz",
-        recipientEmail: "leetony347@yahoo.com",
         email: props.currentUserDetails.email,
         cpnzID: props.currentUserDetails.cpnz_id,
         formData: data,


### PR DESCRIPTION
## Context

<!-- Include contextual info that can't be found in the linked issue. Why are you making this change? -->

To avoid accidental email sendings to actual police email, we move police recipient email to env variable for both logon and amendment

## What Changed?

<!-- What changes did you make? -->
`api/controller/emailController.ts`
`web/src/components/logon/LogonForm.tsx`

## How To Review

<!-- What (rough) order should the reviewer view your files? -->

1. Replace your own personal email in .env file
2. Try to logon and make a amendment, see if you are able to receive the emails.

## Testing

<!-- What testing did you do, if any? -->
Tested mannually, all functionalities preserved.

## Risks

<!-- Where should the reviewer focus on (if any)? -->
N/A

## Notes
N/A
