### PR TITLE
Cpnz/tony fix empty observation

### DIFF
--- a/api/controller/LogOffController.ts
+++ b/api/controller/LogOffController.ts
@@ -7,6 +7,7 @@ import { z } from "zod";
 
 const EMAIL_API_KEY: string = process.env.RESEND_API_KEY as string;
 const CPNZ_APP_EMAIL = "ecc@cpnz.org.nz";
+const POLICE_EMAIL = process.env.CPNZ_ECC_RECIPIENT_EMAIL;
 const resend = new Resend(EMAIL_API_KEY);
 
 const reportSchema = z.object({
@@ -41,7 +42,6 @@ const statsSchema = z.object({
 });
 
 const emailSchema = z.object({
-  recipientEmail: z.string(),
   data: z.object({
     cpnzID: z.string(),
     email: z.string(),
@@ -76,7 +76,7 @@ export const logOffEmail = async (req: Request, res: Response) => {
 
   const ObserverFullName = `${observerName.first_names} ${observerName.surname}`;
 
-  const { recipientEmail, data }: z.infer<typeof emailSchema> =
+  const {data }: z.infer<typeof emailSchema> =
     parseResult.data;
 
   // Check if the API key is provided
@@ -135,7 +135,7 @@ export const logOffEmail = async (req: Request, res: Response) => {
   try {
     const email = await resend.emails.send({
       from: `CPNZ <${CPNZ_APP_EMAIL}>`,
-      to: [`${recipientEmail}`],
+      to: [`${POLICE_EMAIL}`],
       subject: `CPNZ - Log Off - Patrol ID: ${data.cpnzID} - Shift ID: ${data.formData.shiftId}`,
       html: `
             <div style="font-family: Arial, sans-serif; line-height: 1.8;">

--- a/api/controller/gmailController.ts
+++ b/api/controller/gmailController.ts
@@ -489,6 +489,20 @@ const watchMails = async (req: Request, res: Response): Promise<void> => {
   }
 };
 
+const getAllMails = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const responseData = await getMails();
+    await callWatchMailsAPI();
+    res.status(200).json(responseData);
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response) {
+      res.status(error.response.status).json(error.response.data);
+    } else {
+      res.status(500).json("An unknown error occurred");
+    }
+  }
+};
+
 const checkAndRenewWatch = async () => {
   try {
 
@@ -539,4 +553,4 @@ const stopWatchMails = async (req: Request, res: Response): Promise<void> => {
 // check daily
 setInterval(checkAndRenewWatch, 24 * 60 * 60 * 1000);
 
-export { watchMails, getHistoryRecords, stopWatchMails, saveHistoryIdInDb };
+export { watchMails, getHistoryRecords, stopWatchMails, saveHistoryIdInDb, getAllMails };

--- a/api/routes/email.ts
+++ b/api/routes/email.ts
@@ -1,11 +1,12 @@
 import { Router } from 'express';
 import { sendShiftRequest, handleAmendment } from '../controller/emailController';
-import { watchMails, stopWatchMails } from '../controller/gmailController';
+import { watchMails, stopWatchMails, getAllMails } from '../controller/gmailController';
 
 const emailRoute = Router();
 emailRoute.route('/').post(sendShiftRequest);
 emailRoute.route('/monitorEmails').post(watchMails)
 emailRoute.route('/stopMonitor').post(stopWatchMails)
+emailRoute.route('/getMails').get(getAllMails)
 
 
 emailRoute.route('/amendment')

--- a/web/src/components/report/ReportObservation.tsx
+++ b/web/src/components/report/ReportObservation.tsx
@@ -25,7 +25,7 @@ interface ReportObservationProps {
   form: UseFormReturn<z.infer<typeof reportFormSchema>>;
   fields: Observation[];
   setObservationsList: (value: z.infer<typeof formObservationSchema>) => void;
-  append: any;
+  replace: any;
   remove: any;
   update: any;
 }
@@ -62,11 +62,11 @@ const addObservation = (
   newObservation: Observation,
   fields: Observation[],
   setFields: any,
-  append: any
+  replace: any
 ) => {
   const updatedFields = [...fields, newObservation];
   setFields(updatedFields);
-  append(newObservation);
+  replace(updatedFields)
   localStorage.setItem("observations", JSON.stringify(updatedFields));
   console.log(JSON.parse(localStorage.getItem("observations")!).length);
 };
@@ -89,10 +89,11 @@ const ReportObservation = ({
   form,
   fields,
   setObservationsList,
-  append,
+  replace,
   remove,
   update,
 }: ReportObservationProps) => {
+
   const { address } = useCurrentLocation();
   const date = new Date();
   let parsedDate = "";
@@ -149,7 +150,7 @@ const ReportObservation = ({
       newObservation.category &&
       newObservation.description
     ) {
-      addObservation(newObservation, fields, setObservationsList, append);
+      addObservation(newObservation, fields, setObservationsList, replace);
       setNewObservation({
         location: address,
         description: "",

--- a/web/src/pages/Report.tsx
+++ b/web/src/pages/Report.tsx
@@ -129,7 +129,6 @@ export default function Report() {
     try {
       setSubmitting(true);
       await axios.post(`${import.meta.env.VITE_API_URL}/logoff/`, {
-        recipientEmail: "jasonabc0626@gmail.com",
         data,
       });
       console.log(formData, statistics);

--- a/web/src/pages/Report.tsx
+++ b/web/src/pages/Report.tsx
@@ -58,10 +58,11 @@ export default function Report() {
     },
   });
 
-  const { fields, append, remove, update } = useFieldArray({
+  const { fields, replace, remove, update } = useFieldArray({
     control: form.control,
     name: "observations",
   });
+  
 
   const onSubmit = (data: z.infer<typeof reportFormSchema>) => {
     setFormData(data);
@@ -166,7 +167,7 @@ export default function Report() {
               form={form}
               fields={fields}
               setObservationsList={setObservationsList}
-              append={append}
+              replace={replace}
               remove={remove}
               update={update}
             />


### PR DESCRIPTION
## Context

<!-- Include contextual info that can't be found in the linked issue. Why are you making this change? -->
The observation feat has a bug that a empty observation will add to the list along with the intended observation when the initial observation list is empty. This PR fixed this bug.

## What Changed?

<!-- What changes did you make? -->
There are only some minor tweaks applied in:
`web/src/components/report/ReportObservation.tsx`
`web/src/pages/Report.tsx`

Basically, instead of using `append` in `react-hook-form` which create the initial weired behaviour, we replaced it with `replace`.
Since the list is updated by `const updatedFields = [...fields, newObservation]`
We can just do `replace(updatedFields)`
This approach ensures no empty observation being added.

**Others:**

1. Adding back `getMails` route, when `watch` instance inactivated, patrollers admin can press a button to call this route, it fetch all _un-read_ emails in inbox and **re-initilize** a new `watch` instance
2. Refactor and isolate _police recipient email_ to backend in `logoff` as well


## How To Review

<!-- What (rough) order should the reviewer view your files? -->
review file changes in this PR

## Testing

<!-- What testing did you do, if any? -->
**Manual testing** has done by myself and Deasy

1. The bug has fixed, no empty observation added, and all previous functionalities preserved.

## Risks
N/A
<!-- Where should the reviewer focus on (if any)? -->

## Notes
N/A
